### PR TITLE
Adds EntrySnapshot

### DIFF
--- a/src/Management/EntrySnapshot.php
+++ b/src/Management/EntrySnapshot.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * @copyright 2015-2017 Contentful GmbH
+ * @license   MIT
+ */
+
+namespace Contentful\Management;
+
+use Contentful\DateHelper;
+
+class EntrySnapshot implements SpaceScopedResourceInterface
+{
+    /**
+     * @var SystemProperties
+     */
+    private $sys;
+
+    /**
+     * @var array[]
+     */
+    private $fields = [];
+
+    /**
+     * @var SystemProperties
+     */
+    private $entrySys;
+
+    public function __construct()
+    {
+        $this->sys = new SystemProperties(['type' => 'Snapshot', 'snapshotEntityType' => 'Entry']);
+        $this->entrySys = new SystemProperties(['type' => 'Entry']);
+    }
+
+    /**
+     * @return SystemProperties
+     */
+    public function getSystemProperties(): SystemProperties
+    {
+        return $this->sys;
+    }
+
+    public function getResourceUrlPart(): string
+    {
+        return 'entries';
+    }
+
+    /**
+     * @return array[]
+     */
+    public function getFields(): array
+    {
+        return $this->fields;
+    }
+
+    /**
+     * @param string $name
+     * @param string $locale
+     *
+     * @return mixed
+     */
+    public function getField(string $name, string $locale)
+    {
+        if (!isset($this->fields[$name][$locale])) {
+            return null;
+        }
+
+        return $this->fields[$name][$locale];
+    }
+
+    /**
+     * @return SystemProperties
+     */
+    public function getEntrySystemProperties(): SystemProperties
+    {
+        return $this->entrySys;
+    }
+
+    /**
+     * Returns an object to be used by `json_encode` to serialize objects of this class.
+     *
+     * @return object
+     *
+     * @see http://php.net/manual/en/jsonserializable.jsonserialize.php JsonSerializable::jsonSerialize
+     */
+    public function jsonSerialize()
+    {
+        $fields = [];
+
+        foreach ($this->fields as $fieldName => $fieldData) {
+            $formattedData = [];
+            foreach ($fieldData as $locale => $data) {
+                if ($data instanceof \DateTimeImmutable) {
+                    $value = DateHelper::formatForJson($data);
+                } elseif ($data instanceof \DateTime) {
+                    $dt = \DateTimeImmutable::createFromMutable($data);
+                    $value = DateHelper::formatForJson($dt);
+                } elseif (is_array($data)) {
+                    $value = array_map(function ($value) {
+                        if ($value instanceof \DateTimeImmutable) {
+                            return DateHelper::formatForJson($value);
+                        }
+                        if ($value instanceof \DateTime) {
+                            $dt = \DateTimeImmutable::createFromMutable($value);
+
+                            return DateHelper::formatForJson($dt);
+                        }
+
+                        return $value;
+                    }, $data);
+                } else {
+                    $value = $data;
+                }
+                $formattedData[$locale] = $value;
+            }
+            $fields[$fieldName] = (object) $formattedData;
+        }
+
+        return (object) [
+            'snapshot' => [
+                'fields' => (object) $fields,
+                'sys' => $this->entrySys,
+            ],
+            'sys' => $this->sys,
+        ];
+    }
+}

--- a/src/Management/SpaceManager.php
+++ b/src/Management/SpaceManager.php
@@ -257,6 +257,30 @@ class SpaceManager
     }
 
     /**
+     * @param string $entryId
+     * @param string $snapshotId
+     *
+     * @return EntrySnapshot
+     */
+    public function getEntrySnapshot(string $entryId, string $snapshotId): EntrySnapshot
+    {
+        $response = $this->client->request('GET', 'spaces/' . $this->spaceId . '/entries/' . $entryId . '/snapshots/' . $snapshotId);
+
+        return $this->builder->buildObjectsFromRawData($response);
+    }
+
+    /**
+     * @param string $entryId
+     * @param Query $query
+     *
+     * @return ResourceArray
+     */
+    public function getEntrySnapshots(string $entryId, Query $query = null): ResourceArray
+    {
+        return $this->getAndBuildCollection('spaces/' . $this->spaceId . '/entries/' . $entryId . '/snapshots', $query);
+    }
+
+    /**
      * @param string $webhookId
      *
      * @return Webhook

--- a/src/Management/SystemProperties.php
+++ b/src/Management/SystemProperties.php
@@ -97,6 +97,16 @@ class SystemProperties implements \JsonSerializable
     private $archivedVersion;
 
     /**
+     * @var string|null
+     */
+    private $snapshotType;
+
+    /**
+     * @var string|null
+     */
+    private $snapshotEntityType;
+
+    /**
      * SystemProperties constructor.
      *
      * @param  array $sys Associative array of sys properties
@@ -120,6 +130,8 @@ class SystemProperties implements \JsonSerializable
         $this->updatedBy = isset($sys['updatedBy']) ? $this->buildLink($sys['updatedBy']) : null;
         $this->publishedBy = isset($sys['publishedBy']) ? $this->buildLink($sys['publishedBy']) : null;
         $this->archivedBy = isset($sys['archivedBy']) ? $this->buildLink($sys['archivedBy']) : null;
+        $this->snapshotType = $sys['snapshotType'] ?? null;
+        $this->snapshotEntityType = $sys['snapshotEntityType'] ?? null;
     }
 
     public static function withType(string $type)
@@ -276,6 +288,22 @@ class SystemProperties implements \JsonSerializable
     }
 
     /**
+     * @return string|null
+     */
+    public function getSnapshotType()
+    {
+        return $this->snapshotType;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSnapshotEntityType()
+    {
+        return $this->snapshotEntityType;
+    }
+
+    /**
      * Returns an object to be used by `json_encode` to serialize objects of this class.
      *
      * @return object
@@ -336,6 +364,12 @@ class SystemProperties implements \JsonSerializable
         }
         if ($this->archivedVersion !== null) {
             $obj->archivedVersion = $this->archivedVersion;
+        }
+        if ($this->snapshotType !== null) {
+            $obj->snapshotType = $this->snapshotType;
+        }
+        if ($this->snapshotEntityType !== null) {
+            $obj->snapshotEntityType = $this->snapshotEntityType;
         }
 
         return $obj;

--- a/tests/E2E/SnapshotTest.php
+++ b/tests/E2E/SnapshotTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * @copyright 2015-2017 Contentful GmbH
+ * @license   MIT
+ */
+
+namespace Contentful\Tests\E2E;
+
+use Contentful\Link;
+use Contentful\Management\Query;
+use Contentful\Management\EntrySnapshot;
+use Contentful\Tests\End2EndTestCase;
+
+class SnapshotTest extends End2EndTestCase
+{
+    /**
+     * @vcr e2e_snapshot_entry_get.json
+     */
+    public function testGetEntrySnapshot()
+    {
+        $manager = $this->getReadWriteSpaceManager();
+
+        $snapshot = $manager->getEntrySnapshot('3LM5FlCdGUIM0Miqc664q6', '3omuk8H8M8wUuqHhxddXtp');
+        $this->assertInstanceOf(EntrySnapshot::class, $snapshot);
+        $this->assertEquals('Josh Lyman', $snapshot->getField('name', 'en-US'));
+        $this->assertEquals('Deputy Chief of Staff', $snapshot->getField('jobTitle', 'en-US'));
+        $this->assertEquals(new Link('person', 'ContentType'), $snapshot->getEntrySystemProperties()->getContentType());
+        $this->assertEquals(1, $snapshot->getEntrySystemProperties()->getPublishedCounter());
+
+        $sys = $snapshot->getSystemProperties();
+        $this->assertEquals('Entry', $sys->getSnapshotEntityType());
+        $this->assertEquals('publish', $sys->getSnapshotType());
+        $this->assertEquals(new Link($this->readWriteSpaceId, 'Space'), $sys->getSpace());
+        $this->assertEquals(new \DateTimeImmutable('2017-06-14T14:11:20.189Z'), $sys->getCreatedAt());
+        $this->assertEquals(new \DateTimeImmutable('2017-06-14T14:11:20.189Z'), $sys->getUpdatedAt());
+    }
+
+    /**
+     * @vcr e2e_snapshot_entry_get_collection.json
+     */
+    public function testGetEntrySnapshots()
+    {
+        $manager = $this->getReadWriteSpaceManager();
+
+        $snapshots = $manager->getEntrySnapshots('3LM5FlCdGUIM0Miqc664q6');
+
+        $this->assertInstanceOf(EntrySnapshot::class, $snapshots[0]);
+
+        $query = (new Query())
+            ->setLimit(1);
+        $snapshots = $manager->getEntrySnapshots('3LM5FlCdGUIM0Miqc664q6', $query);
+        $this->assertInstanceOf(EntrySnapshot::class, $snapshots[0]);
+        $this->assertCount(1, $snapshots);
+
+    }
+}

--- a/tests/Unit/EntrySnapshotTest.php
+++ b/tests/Unit/EntrySnapshotTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @copyright 2015-2017 Contentful GmbH
+ * @license   MIT
+ */
+
+namespace Contentful\Tests\Unit;
+
+use Contentful\Management\ResourceBuilder;
+
+class EntrySnapshotTest extends \PHPUnit_Framework_TestCase
+{
+    public function testJsonSerialize()
+    {
+        $builder = new ResourceBuilder();
+
+         $data = [
+            'sys' => [
+                'type' => 'Snapshot',
+                'snapshotEntityType' => 'Entry',
+            ],
+            'snapshot' => [
+                'fields' => [
+                    'name' => [
+                        'en-US' => 'Consuela Bananahammock',
+                    ],
+                    'jobTitle' => [
+                        'en-US' => 'Princess',
+                    ],
+                ],
+                'sys' => [
+                    'type' => 'Entry',
+                ],
+            ],
+        ];
+
+        $entrySnapshot = $builder->buildObjectsFromRawData($data);
+        $json = '{"snapshot":{"sys":{"type":"Entry"},"fields":{"name":{"en-US":"Consuela Bananahammock"},"jobTitle":{"en-US":"Princess"}}},"sys":{"type":"Snapshot","snapshotEntityType":"Entry"}}';
+
+        $this->assertJsonStringEqualsJsonString($json, json_encode($entrySnapshot));
+    }
+}

--- a/tests/fixtures/e2e_snapshot_entry_get.json
+++ b/tests/fixtures/e2e_snapshot_entry_get.json
@@ -1,0 +1,47 @@
+[{
+    "request": {
+        "method": "GET",
+        "url": "https:\/\/api.contentful.com\/spaces\/34luz0flcmxt\/entries\/3LM5FlCdGUIM0Miqc664q6\/snapshots\/3omuk8H8M8wUuqHhxddXtp",
+        "headers": {
+            "Host": "api.contentful.com",
+            "User-Agent": "GuzzleHttp\/6.2.1 curl\/7.51.0 PHP\/7.1.5",
+            "X-Contentful-User-Agent": "sdk contentful-management.php\/\/0.6.0-dev; platform PHP\/7.1.5; os macOS;",
+            "Accept": "application\/vnd.contentful.management.v1+json",
+            "Accept-Encoding": "gzip"
+        }
+    },
+    "response": {
+        "status": {
+            "http_version": "1.1",
+            "code": "200",
+            "message": "OK"
+        },
+        "headers": {
+            "Access-Control-Allow-Headers": "Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent",
+            "Access-Control-Allow-Methods": "DELETE,GET,HEAD,POST,PUT,OPTIONS",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Expose-Headers": "Etag",
+            "Access-Control-Max-Age": "1728000",
+            "CF-Space-Id": "34luz0flcmxt",
+            "Content-Encoding": "gzip",
+            "Content-Type": "application\/vnd.contentful.management.v1+json",
+            "Date": "Wed, 14 Jun 2017 14:55:29 GMT",
+            "ETag": "W\/\"a6dc33b7e695f6a888dce4ce7f032968\"",
+            "Server": "Contentful",
+            "Strict-Transport-Security": "max-age=15768000",
+            "X-Content-Type-Options": "nosniff",
+            "X-Contentful-RateLimit-Hour-Limit": "180000",
+            "X-Contentful-RateLimit-Hour-Remaining": "179942",
+            "X-Contentful-RateLimit-Reset": "0",
+            "X-Contentful-RateLimit-Second-Limit": "50",
+            "X-Contentful-RateLimit-Second-Remaining": "49",
+            "X-Contentful-Request-Id": "74fac624ab44d081c0b937809f025b35",
+            "Content-Length": "511",
+            "Connection": "keep-alive",
+            "Set-Cookie": "visid_incap_673446=GVmMFGSjQCW2bXShb1pbJmBOQVkAAAAAQUIPAAAAAADjGvaiXVe7kQaXaeS+YZDk; expires=Thu, 14 Jun 2018 09:13:56 GMT; path=\/; Domain=.contentful.com, nlbi_673446=W2AFJ3AHsAb\/A1cj6lKYhQAAAAAssbxV9lT8qDhsSr38QmKQ; path=\/; Domain=.contentful.com, incap_ses_259_673446=tDlPGjWGWGDKawz44SeYA2BOQVkAAAAAwmHFceSTQIdYYDj0XI85pA==; path=\/; Domain=.contentful.com",
+            "X-Iinfo": "9-27808256-27808274 NNNN CT(88 88 0) RT(1497452128509 56) q(0 0 2 -1) r(4 4) U5",
+            "X-CDN": "Incapsula"
+        },
+        "body": "{\n  \"sys\": {\n    \"type\": \"Snapshot\",\n    \"snapshotType\": \"publish\",\n    \"snapshotEntityType\": \"Entry\",\n    \"id\": \"3omuk8H8M8wUuqHhxddXtp\",\n    \"createdAt\": \"2017-06-14T14:11:20.189Z\",\n    \"createdBy\": {\n      \"sys\": {\n        \"type\": \"Link\",\n        \"linkType\": \"User\",\n        \"id\": \"1CECdY5ZhqJapGieg6QS9P\"\n      }\n    },\n    \"updatedAt\": \"2017-06-14T14:11:20.189Z\",\n    \"updatedBy\": {\n      \"sys\": {\n        \"type\": \"Link\",\n        \"linkType\": \"User\",\n        \"id\": \"1CECdY5ZhqJapGieg6QS9P\"\n      }\n    },\n    \"space\": {\n      \"sys\": {\n        \"type\": \"Link\",\n        \"linkType\": \"Space\",\n        \"id\": \"34luz0flcmxt\"\n      }\n    }\n  },\n  \"snapshot\": {\n    \"fields\": {\n      \"name\": {\n        \"en-US\": \"Josh Lyman\"\n      },\n      \"jobTitle\": {\n        \"en-US\": \"Deputy Chief of Staff\"\n      }\n    },\n    \"sys\": {\n      \"id\": \"3LM5FlCdGUIM0Miqc664q6\",\n      \"type\": \"Entry\",\n      \"createdAt\": \"2017-06-14T14:10:59.317Z\",\n      \"createdBy\": {\n        \"sys\": {\n          \"type\": \"Link\",\n          \"linkType\": \"User\",\n          \"id\": \"1CECdY5ZhqJapGieg6QS9P\"\n        }\n      },\n      \"space\": {\n        \"sys\": {\n          \"type\": \"Link\",\n          \"linkType\": \"Space\",\n          \"id\": \"34luz0flcmxt\"\n        }\n      },\n      \"contentType\": {\n        \"sys\": {\n          \"type\": \"Link\",\n          \"linkType\": \"ContentType\",\n          \"id\": \"person\"\n        }\n      },\n      \"version\": 20,\n      \"updatedAt\": \"2017-06-14T14:11:20.177Z\",\n      \"updatedBy\": {\n        \"sys\": {\n          \"type\": \"Link\",\n          \"linkType\": \"User\",\n          \"id\": \"1CECdY5ZhqJapGieg6QS9P\"\n        }\n      },\n      \"firstPublishedAt\": \"2017-06-14T14:11:20.177Z\",\n      \"publishedCounter\": 1,\n      \"publishedAt\": \"2017-06-14T14:11:20.177Z\",\n      \"publishedBy\": {\n        \"sys\": {\n          \"type\": \"Link\",\n          \"linkType\": \"User\",\n          \"id\": \"1CECdY5ZhqJapGieg6QS9P\"\n        }\n      },\n      \"publishedVersion\": 19\n    }\n  }\n}\n"
+    }
+}]

--- a/tests/fixtures/e2e_snapshot_entry_get_collection.json
+++ b/tests/fixtures/e2e_snapshot_entry_get_collection.json
@@ -1,0 +1,93 @@
+[{
+    "request": {
+        "method": "GET",
+        "url": "https:\/\/api.contentful.com\/spaces\/34luz0flcmxt\/entries\/3LM5FlCdGUIM0Miqc664q6\/snapshots",
+        "headers": {
+            "Host": "api.contentful.com",
+            "User-Agent": "GuzzleHttp\/6.2.1 curl\/7.51.0 PHP\/7.1.5",
+            "X-Contentful-User-Agent": "sdk contentful-management.php\/\/0.6.0-dev; platform PHP\/7.1.5; os macOS;",
+            "Accept": "application\/vnd.contentful.management.v1+json",
+            "Accept-Encoding": "gzip"
+        }
+    },
+    "response": {
+        "status": {
+            "http_version": "1.1",
+            "code": "200",
+            "message": "OK"
+        },
+        "headers": {
+            "Access-Control-Allow-Headers": "Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent",
+            "Access-Control-Allow-Methods": "DELETE,GET,HEAD,POST,PUT,OPTIONS",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Expose-Headers": "Etag",
+            "Access-Control-Max-Age": "1728000",
+            "CF-Space-Id": "34luz0flcmxt",
+            "Content-Encoding": "gzip",
+            "Content-Type": "application\/vnd.contentful.management.v1+json",
+            "Date": "Wed, 14 Jun 2017 14:55:30 GMT",
+            "ETag": "W\/\"a5fa6bda54cebdafdca4f852bf443108\"",
+            "Server": "Contentful",
+            "Strict-Transport-Security": "max-age=15768000",
+            "X-Content-Type-Options": "nosniff",
+            "X-Contentful-RateLimit-Hour-Limit": "180000",
+            "X-Contentful-RateLimit-Hour-Remaining": "179941",
+            "X-Contentful-RateLimit-Reset": "0",
+            "X-Contentful-RateLimit-Second-Limit": "50",
+            "X-Contentful-RateLimit-Second-Remaining": "49",
+            "X-Contentful-Request-Id": "96ba7c83e656f60713fcac311ab513fe",
+            "Content-Length": "715",
+            "Connection": "keep-alive",
+            "Set-Cookie": "visid_incap_673446=i3XkEgFjTH23YdtHZCWBUGFOQVkAAAAAQUIPAAAAAACgCxy52tOvpO53HFrXmLDg; expires=Thu, 14 Jun 2018 09:13:56 GMT; path=\/; Domain=.contentful.com, nlbi_673446=V10WTEKDc0ewy5sc6lKYhQAAAADpLK1E8rGI1I\/T\/uSCASEl; path=\/; Domain=.contentful.com, incap_ses_259_673446=SX3yTJJQ+w9NbQz44SeYA2FOQVkAAAAA2CnhifTzFHQHt10RjGZApA==; path=\/; Domain=.contentful.com",
+            "X-Iinfo": "7-22276469-22276477 NNNN CT(87 182 0) RT(1497452129160 24) q(0 0 3 -1) r(5 5) U5",
+            "X-CDN": "Incapsula"
+        },
+        "body": "{\n  \"sys\": {\n    \"type\": \"Array\"\n  },\n  \"items\": [\n    {\n      \"sys\": {\n        \"type\": \"Snapshot\",\n        \"snapshotType\": \"publish\",\n        \"snapshotEntityType\": \"Entry\",\n        \"id\": \"6WD9boMFYzOLU85acOngiM\",\n        \"createdAt\": \"2017-06-14T14:11:28.926Z\",\n        \"createdBy\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"User\",\n            \"id\": \"1CECdY5ZhqJapGieg6QS9P\"\n          }\n        },\n        \"updatedAt\": \"2017-06-14T14:11:28.926Z\",\n        \"updatedBy\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"User\",\n            \"id\": \"1CECdY5ZhqJapGieg6QS9P\"\n          }\n        },\n        \"space\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"Space\",\n            \"id\": \"34luz0flcmxt\"\n          }\n        }\n      },\n      \"snapshot\": {\n        \"fields\": {\n          \"name\": {\n            \"en-US\": \"Josh Lyman\"\n          },\n          \"jobTitle\": {\n            \"en-US\": \"Chief of Staff\"\n          }\n        },\n        \"sys\": {\n          \"id\": \"3LM5FlCdGUIM0Miqc664q6\",\n          \"type\": \"Entry\",\n          \"createdAt\": \"2017-06-14T14:10:59.317Z\",\n          \"createdBy\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"User\",\n              \"id\": \"1CECdY5ZhqJapGieg6QS9P\"\n            }\n          },\n          \"space\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"Space\",\n              \"id\": \"34luz0flcmxt\"\n            }\n          },\n          \"contentType\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"ContentType\",\n              \"id\": \"person\"\n            }\n          },\n          \"version\": 22,\n          \"updatedAt\": \"2017-06-14T14:11:28.913Z\",\n          \"updatedBy\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"User\",\n              \"id\": \"1CECdY5ZhqJapGieg6QS9P\"\n            }\n          },\n          \"firstPublishedAt\": \"2017-06-14T14:11:20.177Z\",\n          \"publishedCounter\": 2,\n          \"publishedAt\": \"2017-06-14T14:11:28.913Z\",\n          \"publishedBy\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"User\",\n              \"id\": \"1CECdY5ZhqJapGieg6QS9P\"\n            }\n          },\n          \"publishedVersion\": 21\n        }\n      }\n    },\n    {\n      \"sys\": {\n        \"type\": \"Snapshot\",\n        \"snapshotType\": \"publish\",\n        \"snapshotEntityType\": \"Entry\",\n        \"id\": \"3omuk8H8M8wUuqHhxddXtp\",\n        \"createdAt\": \"2017-06-14T14:11:20.189Z\",\n        \"createdBy\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"User\",\n            \"id\": \"1CECdY5ZhqJapGieg6QS9P\"\n          }\n        },\n        \"updatedAt\": \"2017-06-14T14:11:20.189Z\",\n        \"updatedBy\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"User\",\n            \"id\": \"1CECdY5ZhqJapGieg6QS9P\"\n          }\n        },\n        \"space\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"Space\",\n            \"id\": \"34luz0flcmxt\"\n          }\n        }\n      },\n      \"snapshot\": {\n        \"fields\": {\n          \"name\": {\n            \"en-US\": \"Josh Lyman\"\n          },\n          \"jobTitle\": {\n            \"en-US\": \"Deputy Chief of Staff\"\n          }\n        },\n        \"sys\": {\n          \"id\": \"3LM5FlCdGUIM0Miqc664q6\",\n          \"type\": \"Entry\",\n          \"createdAt\": \"2017-06-14T14:10:59.317Z\",\n          \"createdBy\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"User\",\n              \"id\": \"1CECdY5ZhqJapGieg6QS9P\"\n            }\n          },\n          \"space\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"Space\",\n              \"id\": \"34luz0flcmxt\"\n            }\n          },\n          \"contentType\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"ContentType\",\n              \"id\": \"person\"\n            }\n          },\n          \"version\": 20,\n          \"updatedAt\": \"2017-06-14T14:11:20.177Z\",\n          \"updatedBy\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"User\",\n              \"id\": \"1CECdY5ZhqJapGieg6QS9P\"\n            }\n          },\n          \"firstPublishedAt\": \"2017-06-14T14:11:20.177Z\",\n          \"publishedCounter\": 1,\n          \"publishedAt\": \"2017-06-14T14:11:20.177Z\",\n          \"publishedBy\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"User\",\n              \"id\": \"1CECdY5ZhqJapGieg6QS9P\"\n            }\n          },\n          \"publishedVersion\": 19\n        }\n      }\n    }\n  ],\n  \"skip\": 0,\n  \"limit\": 100\n}\n"
+    }
+},{
+    "request": {
+        "method": "GET",
+        "url": "https:\/\/api.contentful.com\/spaces\/34luz0flcmxt\/entries\/3LM5FlCdGUIM0Miqc664q6\/snapshots?limit=1",
+        "headers": {
+            "Host": "api.contentful.com",
+            "User-Agent": "GuzzleHttp\/6.2.1 curl\/7.51.0 PHP\/7.1.5",
+            "X-Contentful-User-Agent": "sdk contentful-management.php\/\/0.6.0-dev; platform PHP\/7.1.5; os macOS;",
+            "Accept": "application\/vnd.contentful.management.v1+json",
+            "Accept-Encoding": "gzip"
+        }
+    },
+    "response": {
+        "status": {
+            "http_version": "1.1",
+            "code": "200",
+            "message": "OK"
+        },
+        "headers": {
+            "Access-Control-Allow-Headers": "Accept,Accept-Language,Authorization,Cache-Control,Content-Length,Content-Range,Content-Type,DNT,Destination,Expires,If-Match,If-Modified-Since,If-None-Match,Keep-Alive,Last-Modified,Origin,Pragma,Range,User-Agent,X-Http-Method-Override,X-Mx-ReqToken,X-Requested-With,X-Contentful-Version,X-Contentful-Content-Type,X-Contentful-Organization,X-Contentful-Skip-Transformation,X-Contentful-User-Agent",
+            "Access-Control-Allow-Methods": "DELETE,GET,HEAD,POST,PUT,OPTIONS",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Expose-Headers": "Etag",
+            "Access-Control-Max-Age": "1728000",
+            "CF-Space-Id": "34luz0flcmxt",
+            "Content-Encoding": "gzip",
+            "Content-Type": "application\/vnd.contentful.management.v1+json",
+            "Date": "Wed, 14 Jun 2017 14:55:30 GMT",
+            "ETag": "W\/\"80249351be4be7284bda46e911093fa3\"",
+            "Server": "Contentful",
+            "Strict-Transport-Security": "max-age=15768000",
+            "X-Content-Type-Options": "nosniff",
+            "X-Contentful-RateLimit-Hour-Limit": "180000",
+            "X-Contentful-RateLimit-Hour-Remaining": "179940",
+            "X-Contentful-RateLimit-Reset": "0",
+            "X-Contentful-RateLimit-Second-Limit": "50",
+            "X-Contentful-RateLimit-Second-Remaining": "48",
+            "X-Contentful-Request-Id": "8f06be8f3b2c404ae12d3b8f848f6e11",
+            "Content-Length": "582",
+            "Connection": "keep-alive",
+            "Set-Cookie": "visid_incap_673446=Heh9fNVdSsmYYQVKG8LNRmJOQVkAAAAAQUIPAAAAAACIW7ziNzhE9K6BLF9pRNXA; expires=Thu, 14 Jun 2018 09:13:56 GMT; path=\/; Domain=.contentful.com, nlbi_673446=HlOFGxT4xiIlwHZw6lKYhQAAAABPsotyEQ0CTRwg9cHEwL2Z; path=\/; Domain=.contentful.com, incap_ses_259_673446=6e09C4ClNFhJbgz44SeYA2JOQVkAAAAAYc8Yu0OcZ9\/10M9m6OaAvA==; path=\/; Domain=.contentful.com",
+            "X-Iinfo": "9-27808639-27808274 PNNN RT(1497452129825 27) q(0 0 0 -1) r(2 2) U5",
+            "X-CDN": "Incapsula"
+        },
+        "body": "{\n  \"sys\": {\n    \"type\": \"Array\"\n  },\n  \"items\": [\n    {\n      \"sys\": {\n        \"type\": \"Snapshot\",\n        \"snapshotType\": \"publish\",\n        \"snapshotEntityType\": \"Entry\",\n        \"id\": \"6WD9boMFYzOLU85acOngiM\",\n        \"createdAt\": \"2017-06-14T14:11:28.926Z\",\n        \"createdBy\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"User\",\n            \"id\": \"1CECdY5ZhqJapGieg6QS9P\"\n          }\n        },\n        \"updatedAt\": \"2017-06-14T14:11:28.926Z\",\n        \"updatedBy\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"User\",\n            \"id\": \"1CECdY5ZhqJapGieg6QS9P\"\n          }\n        },\n        \"space\": {\n          \"sys\": {\n            \"type\": \"Link\",\n            \"linkType\": \"Space\",\n            \"id\": \"34luz0flcmxt\"\n          }\n        }\n      },\n      \"snapshot\": {\n        \"fields\": {\n          \"name\": {\n            \"en-US\": \"Josh Lyman\"\n          },\n          \"jobTitle\": {\n            \"en-US\": \"Chief of Staff\"\n          }\n        },\n        \"sys\": {\n          \"id\": \"3LM5FlCdGUIM0Miqc664q6\",\n          \"type\": \"Entry\",\n          \"createdAt\": \"2017-06-14T14:10:59.317Z\",\n          \"createdBy\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"User\",\n              \"id\": \"1CECdY5ZhqJapGieg6QS9P\"\n            }\n          },\n          \"space\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"Space\",\n              \"id\": \"34luz0flcmxt\"\n            }\n          },\n          \"contentType\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"ContentType\",\n              \"id\": \"person\"\n            }\n          },\n          \"version\": 22,\n          \"updatedAt\": \"2017-06-14T14:11:28.913Z\",\n          \"updatedBy\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"User\",\n              \"id\": \"1CECdY5ZhqJapGieg6QS9P\"\n            }\n          },\n          \"firstPublishedAt\": \"2017-06-14T14:11:20.177Z\",\n          \"publishedCounter\": 2,\n          \"publishedAt\": \"2017-06-14T14:11:28.913Z\",\n          \"publishedBy\": {\n            \"sys\": {\n              \"type\": \"Link\",\n              \"linkType\": \"User\",\n              \"id\": \"1CECdY5ZhqJapGieg6QS9P\"\n            }\n          },\n          \"publishedVersion\": 21\n        }\n      }\n    }\n  ],\n  \"skip\": 0,\n  \"limit\": 1\n}\n"
+    }
+}]


### PR DESCRIPTION
It should be pretty straightforward, but a couple noteworthy points:
- I added a default `total` value in the `ResourceBuilder` when creating a `ResourceArray`, so it also works when there is not `total` in the API response.
- I map `snapshot.fields` to `EntrySnapshot::$fields` and `snapshot.sys` to `EntrySnapshot::$entrySys`. I removed the `snapshot` level in the `EntrySnapshot` class, so users can access directly to `fields` and `entrySys`. I'm not 100% sure about the naming, maybe it should be `entryFields` for consistency?