### PR TITLE
Changes management of entry in EntrySnapshot

### DIFF
--- a/src/Management/EntrySnapshot.php
+++ b/src/Management/EntrySnapshot.php
@@ -9,8 +9,6 @@
 
 namespace Contentful\Management;
 
-use Contentful\DateHelper;
-
 /**
  * EntrySnapshot class.
  *
@@ -27,14 +25,9 @@ class EntrySnapshot implements SpaceScopedResourceInterface
     private $sys;
 
     /**
-     * @var array[]
+     * @var Entry
      */
-    private $fields = [];
-
-    /**
-     * @var SystemProperties
-     */
-    private $entrySys;
+    private $entry;
 
     /**
      * EntrySnapshot constructor.
@@ -42,7 +35,6 @@ class EntrySnapshot implements SpaceScopedResourceInterface
     public function __construct()
     {
         $this->sys = new SystemProperties(['type' => 'Snapshot', 'snapshotEntityType' => 'Entry']);
-        $this->entrySys = new SystemProperties(['type' => 'Entry']);
     }
 
     /**
@@ -62,30 +54,11 @@ class EntrySnapshot implements SpaceScopedResourceInterface
     }
 
     /**
-     * @return array[]
+     * @return Entry
      */
-    public function getFields(): array
+    public function getEntry(): Entry
     {
-        return $this->fields;
-    }
-
-    /**
-     * @param string $name
-     * @param string $locale
-     *
-     * @return mixed
-     */
-    public function getField(string $name, string $locale)
-    {
-        return $this->fields[$name][$locale] ?? null;
-    }
-
-    /**
-     * @return SystemProperties
-     */
-    public function getEntrySystemProperties(): SystemProperties
-    {
-        return $this->entrySys;
+        return $this->entry;
     }
 
     /**
@@ -97,42 +70,8 @@ class EntrySnapshot implements SpaceScopedResourceInterface
      */
     public function jsonSerialize()
     {
-        $fields = [];
-
-        foreach ($this->fields as $fieldName => $fieldData) {
-            $formattedData = [];
-            foreach ($fieldData as $locale => $data) {
-                if ($data instanceof \DateTimeImmutable) {
-                    $value = DateHelper::formatForJson($data);
-                } elseif ($data instanceof \DateTime) {
-                    $dt = \DateTimeImmutable::createFromMutable($data);
-                    $value = DateHelper::formatForJson($dt);
-                } elseif (is_array($data)) {
-                    $value = array_map(function ($value) {
-                        if ($value instanceof \DateTimeImmutable) {
-                            return DateHelper::formatForJson($value);
-                        }
-                        if ($value instanceof \DateTime) {
-                            $dt = \DateTimeImmutable::createFromMutable($value);
-
-                            return DateHelper::formatForJson($dt);
-                        }
-
-                        return $value;
-                    }, $data);
-                } else {
-                    $value = $data;
-                }
-                $formattedData[$locale] = $value;
-            }
-            $fields[$fieldName] = (object) $formattedData;
-        }
-
         return (object) [
-            'snapshot' => [
-                'fields' => (object) $fields,
-                'sys' => $this->entrySys,
-            ],
+            'snapshot' => $this->entry,
             'sys' => $this->sys,
         ];
     }

--- a/src/Management/ResourceBuilder.php
+++ b/src/Management/ResourceBuilder.php
@@ -318,8 +318,7 @@ class ResourceBuilder
     {
         return $this->createObject(EntrySnapshot::class, [
             'sys' => $this->buildSystemProperties($data['sys']),
-            'fields' => $data['snapshot']['fields'],
-            'entrySys' => $this->buildSystemProperties($data['snapshot']['sys']),
+            'entry' => $this->buildEntry($data['snapshot']),
         ]);
     }
 

--- a/tests/E2E/SnapshotTest.php
+++ b/tests/E2E/SnapshotTest.php
@@ -25,10 +25,11 @@ class SnapshotTest extends End2EndTestCase
 
         $snapshot = $manager->getEntrySnapshot('3LM5FlCdGUIM0Miqc664q6', '3omuk8H8M8wUuqHhxddXtp');
         $this->assertInstanceOf(EntrySnapshot::class, $snapshot);
-        $this->assertEquals('Josh Lyman', $snapshot->getField('name', 'en-US'));
-        $this->assertEquals('Deputy Chief of Staff', $snapshot->getField('jobTitle', 'en-US'));
-        $this->assertEquals(new Link('person', 'ContentType'), $snapshot->getEntrySystemProperties()->getContentType());
-        $this->assertEquals(1, $snapshot->getEntrySystemProperties()->getPublishedCounter());
+        $entry = $snapshot->getEntry();
+        $this->assertEquals('Josh Lyman', $entry->getField('name', 'en-US'));
+        $this->assertEquals('Deputy Chief of Staff', $entry->getField('jobTitle', 'en-US'));
+        $this->assertEquals(new Link('person', 'ContentType'), $entry->getSystemProperties()->getContentType());
+        $this->assertEquals(1, $entry->getSystemProperties()->getPublishedCounter());
 
         $sys = $snapshot->getSystemProperties();
         $this->assertEquals('Entry', $sys->getSnapshotEntityType());


### PR DESCRIPTION
The structure of an Entry inside an EntrySnapshot was determined by the initial assumption that:

- The Entry had no system properties, which turned out to be incorrect (it has)
- We were going to implement something to enforce relationship between Entry and ContentType, which we won't do any time soon (or at all).

Because of this, I'm proposing changing the way the entry is managed. With this, we are more correctly aligned with what the API does, and the code is much simpler in result, without needless duplication. Plus in the future, should we add more features to the Entry class, they will be automatically available in the EntrySnapshot class as well.

This is also consistent with what other SDKs do (Java, Ruby, Python).