### PR TITLE
Defines PHPUnit as dev dependency, and bumps required PHPUnit test listener version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ branches:
 
 before_install:
  - wget https://github.com/satooshi/php-coveralls/releases/download/v1.0.1/coveralls.phar
- - wget -O phpunit.phar https://phar.phpunit.de/phpunit-5.7.phar
 
 install:
   - composer self-update
@@ -22,7 +21,7 @@ install:
 script:
  - vendor/bin/parallel-lint src/
  - vendor/bin/parallel-lint tests/
- - php phpunit.phar -v
+ - vendor/bin/phpunit
 
 after_success:
  - travis_retry php coveralls.phar -v

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,8 @@
     "contentful/contentful": "dev-master@dev"
   },
   "require-dev": {
-    "php-vcr/phpunit-testlistener-vcr": "^1.1",
+    "phpunit/phpunit": "^6.2",
+    "php-vcr/phpunit-testlistener-vcr": "^3.0",
     "php-vcr/php-vcr": "1.3.1",
     "jakub-onderka/php-parallel-lint": "^0.9.2",
     "jakub-onderka/php-console-highlighter": "^0.3.2"
@@ -22,5 +23,8 @@
     "branch-alias": {
       "dev-master": "0.6.0-dev"
     }
+  },
+  "scripts": {
+      "test": "vendor/bin/phpunit"
   }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,7 +20,7 @@
     </logging>
 
     <listeners>
-        <listener class="PHPUnit_Util_Log_VCR" file="vendor/php-vcr/phpunit-testlistener-vcr/PHPUnit/Util/Log/VCR.php" />
+        <listener class="VCR\PHPUnit\TestListener\VCRTestListener" file="vendor/php-vcr/phpunit-testlistener-vcr/src/VCRTestListener.php" />
     </listeners>
 
     <filter>

--- a/src/Management/Resource/Entry.php
+++ b/src/Management/Resource/Entry.php
@@ -74,6 +74,25 @@ class Entry implements SpaceScopedResourceInterface, Publishable, Archivable, De
     }
 
     /**
+     * @param string|null $locale
+     *
+     * @return array
+     */
+    public function getFields(string $locale = null): array
+    {
+        if ($locale === null) {
+            return $this->fields;
+        }
+
+        $fields = [];
+        foreach ($this->fields as $name => $field) {
+            $fields[$name] = $field[$locale] ?? null;
+        }
+
+        return $fields;
+    }
+
+    /**
      * @param string $name
      * @param string $locale
      * @param mixed  $value

--- a/tests/E2E/EntryTest.php
+++ b/tests/E2E/EntryTest.php
@@ -73,6 +73,8 @@ class EntryTest extends End2EndTestCase
 
         $manager->create($entry);
         $this->assertNotNull($entry->getSystemProperties()->getId());
+        $this->assertEquals(['name' => 'A name'], $entry->getFields('en-US'));
+        $this->assertEquals(['name' => ['en-US' => 'A name']], $entry->getFields());
 
         $entry->setField('name', 'en-US', 'A better name');
 
@@ -121,5 +123,7 @@ class EntryTest extends End2EndTestCase
         // Without a default value in the ResourceBuilder, this call would cause a
         // "Undefined index: fields" error message
         $manager->getEntry('2cOd0Aho3WkowMgk2C02iy');
+
+        $this->markTestAsPassed();
     }
 }

--- a/tests/E2E/ErrorTest.php
+++ b/tests/E2E/ErrorTest.php
@@ -68,6 +68,8 @@ class ErrorTest extends End2EndTestCase
         try {
             $spaceManager->update($fakeAsset);
         } catch (VersionMismatchException $e) {
+            $this->markTestAsPassed();
+
             return;
         } finally {
             $spaceManager->delete($asset);

--- a/tests/E2E/WebhookTest.php
+++ b/tests/E2E/WebhookTest.php
@@ -157,5 +157,7 @@ class WebhookTest extends End2EndTestCase
         $manager = $this->getReadWriteSpaceManager();
 
         $manager->delete($webhook);
+
+        $this->markTestAsPassed();
     }
 }

--- a/tests/End2EndTestCase.php
+++ b/tests/End2EndTestCase.php
@@ -11,8 +11,9 @@ namespace Contentful\Tests;
 
 use Contentful\Management\Client;
 use Contentful\Management\SpaceManager;
+use PHPUnit\Framework\TestCase;
 
-class End2EndTestCase extends \PHPUnit_Framework_TestCase
+class End2EndTestCase extends TestCase
 {
     /**
      * @var string
@@ -59,5 +60,16 @@ class End2EndTestCase extends \PHPUnit_Framework_TestCase
     protected function getReadWriteSpaceManager(): SpaceManager
     {
         return $this->client->getSpaceManager($this->readWriteSpaceId);
+    }
+
+    /**
+     * Creates an empty assertion (true == true).
+     * This is done to mark tests that are expected to simply work (i.e. not throw exceptions).
+     * As PHPUnit does not provide convenience methods for marking a test as passed,
+     * we define one.
+     */
+    protected function markTestAsPassed()
+    {
+        $this->assertTrue(true, 'Test case did not throw an exception and passed.');
     }
 }

--- a/tests/Integration/ContentTypeSnapshotTest.php
+++ b/tests/Integration/ContentTypeSnapshotTest.php
@@ -10,8 +10,9 @@
 namespace Contentful\Tests\Integration;
 
 use Contentful\Management\ResourceBuilder;
+use PHPUnit\Framework\TestCase;
 
-class ContentTypeSnapshotTest extends \PHPUnit_Framework_TestCase
+class ContentTypeSnapshotTest extends TestCase
 {
     public function testJsonSerialize()
     {

--- a/tests/Unit/Exception/BadRequestExceptionTest.php
+++ b/tests/Unit/Exception/BadRequestExceptionTest.php
@@ -13,8 +13,9 @@ use Contentful\Management\Exception\BadRequestException;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
-class BadRequestExceptionTest extends \PHPUnit_Framework_TestCase
+class BadRequestExceptionTest extends TestCase
 {
     public function testExceptionStructure()
     {

--- a/tests/Unit/Exception/DefaultLocaleNotDeletableExceptionTest.php
+++ b/tests/Unit/Exception/DefaultLocaleNotDeletableExceptionTest.php
@@ -13,8 +13,9 @@ use Contentful\Management\Exception\DefaultLocaleNotDeletableException;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
-class DefaultLocaleNotDeletableExceptionTest extends \PHPUnit_Framework_TestCase
+class DefaultLocaleNotDeletableExceptionTest extends TestCase
 {
     public function testExceptionStructure()
     {

--- a/tests/Unit/Exception/FallbackLocaleNotDeletableExceptionTest.php
+++ b/tests/Unit/Exception/FallbackLocaleNotDeletableExceptionTest.php
@@ -13,8 +13,9 @@ use Contentful\Management\Exception\FallbackLocaleNotDeletableException;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
-class FallbackLocaleNotDeletableExceptionTest extends \PHPUnit_Framework_TestCase
+class FallbackLocaleNotDeletableExceptionTest extends TestCase
 {
     public function testExceptionStructure()
     {

--- a/tests/Unit/Exception/FallbackLocaleNotRenameableExceptionTest.php
+++ b/tests/Unit/Exception/FallbackLocaleNotRenameableExceptionTest.php
@@ -13,8 +13,9 @@ use Contentful\Management\Exception\FallbackLocaleNotRenameableException;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
-class FallbackLocaleNotRenameableExceptionTest extends \PHPUnit_Framework_TestCase
+class FallbackLocaleNotRenameableExceptionTest extends TestCase
 {
     public function testExceptionStructure()
     {

--- a/tests/Unit/Exception/InternalServerErrorExceptionTest.php
+++ b/tests/Unit/Exception/InternalServerErrorExceptionTest.php
@@ -13,8 +13,9 @@ use Contentful\Management\Exception\InternalServerErrorException;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
-class InternalServerErrorExceptionTest extends \PHPUnit_Framework_TestCase
+class InternalServerErrorExceptionTest extends TestCase
 {
     public function testExceptionStructure()
     {

--- a/tests/Unit/Exception/MissingKeyExceptionTest.php
+++ b/tests/Unit/Exception/MissingKeyExceptionTest.php
@@ -13,8 +13,9 @@ use Contentful\Management\Exception\MissingKeyException;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
-class MissingKeyExceptionTest extends \PHPUnit_Framework_TestCase
+class MissingKeyExceptionTest extends TestCase
 {
     public function testExceptionStructure()
     {

--- a/tests/Unit/Exception/RateLimitExceededExceptionTest.php
+++ b/tests/Unit/Exception/RateLimitExceededExceptionTest.php
@@ -13,8 +13,9 @@ use Contentful\Management\Exception\RateLimitExceededException;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
-class RateLimitExceededExceptionTest extends \PHPUnit_Framework_TestCase
+class RateLimitExceededExceptionTest extends TestCase
 {
     public function testExceptionStructure()
     {

--- a/tests/Unit/Exception/UnknownKeyExceptionTest.php
+++ b/tests/Unit/Exception/UnknownKeyExceptionTest.php
@@ -13,8 +13,9 @@ use Contentful\Management\Exception\UnknownKeyException;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
-class UnknownKeyExceptionTest extends \PHPUnit_Framework_TestCase
+class UnknownKeyExceptionTest extends TestCase
 {
     public function testExceptionStructure()
     {

--- a/tests/Unit/Exception/UnsupportedMediaTypeExceptionTest.php
+++ b/tests/Unit/Exception/UnsupportedMediaTypeExceptionTest.php
@@ -13,8 +13,9 @@ use Contentful\Management\Exception\UnsupportedMediaTypeException;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
-class UnsupportedMediaTypeExceptionTest extends \PHPUnit_Framework_TestCase
+class UnsupportedMediaTypeExceptionTest extends TestCase
 {
     public function testExceptionStructure()
     {

--- a/tests/Unit/Exception/ValidationFailedExceptionTest.php
+++ b/tests/Unit/Exception/ValidationFailedExceptionTest.php
@@ -13,8 +13,9 @@ use Contentful\Management\Exception\ValidationFailedException;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
-class ValidationFailedExceptionTest extends \PHPUnit_Framework_TestCase
+class ValidationFailedExceptionTest extends TestCase
 {
     public function testExceptionStructure()
     {

--- a/tests/Unit/Exception/VersionMismatchExceptionTest.php
+++ b/tests/Unit/Exception/VersionMismatchExceptionTest.php
@@ -13,8 +13,9 @@ use Contentful\Management\Exception\VersionMismatchException;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use PHPUnit\Framework\TestCase;
 
-class VersionMismatchExceptionTest extends \PHPUnit_Framework_TestCase
+class VersionMismatchExceptionTest extends TestCase
 {
     public function testExceptionStructure()
     {

--- a/tests/Unit/Field/FieldJsonSerializationTest.php
+++ b/tests/Unit/Field/FieldJsonSerializationTest.php
@@ -10,8 +10,9 @@
 namespace Contentful\Tests\Unit\Field;
 
 use Contentful\Management\Field;
+use PHPUnit\Framework\TestCase;
 
-class FieldJsonSerializationTest extends \PHPUnit_Framework_TestCase
+class FieldJsonSerializationTest extends TestCase
 {
     /**
      * @dataProvider fieldProvider

--- a/tests/Unit/Field/LinkFieldTest.php
+++ b/tests/Unit/Field/LinkFieldTest.php
@@ -10,8 +10,9 @@
 namespace Contentful\Tests\Unit\Field;
 
 use Contentful\Management\Field\LinkField;
+use PHPUnit\Framework\TestCase;
 
-class LinkFieldTest extends \PHPUnit_Framework_TestCase
+class LinkFieldTest extends TestCase
 {
     public function testEntryLinkGetSetData()
     {

--- a/tests/Unit/Field/SimpleFieldTest.php
+++ b/tests/Unit/Field/SimpleFieldTest.php
@@ -13,8 +13,9 @@ use Contentful\Management\Field\SymbolField;
 use Contentful\Management\Field\Validation\InValidation;
 use Contentful\Management\Field\Validation\RangeValidation;
 use Contentful\Management\Field\Validation\SizeValidation;
+use PHPUnit\Framework\TestCase;
 
-class SimpleFieldTest extends \PHPUnit_Framework_TestCase
+class SimpleFieldTest extends TestCase
 {
     public function testGetSetData()
     {

--- a/tests/Unit/Field/Validation/AssetFileSizeValidationTest.php
+++ b/tests/Unit/Field/Validation/AssetFileSizeValidationTest.php
@@ -10,8 +10,9 @@
 namespace Unit\FieldValidation;
 
 use Contentful\Management\Field\Validation\AssetFileSizeValidation;
+use PHPUnit\Framework\TestCase;
 
-class AssetFileSizeValidationTest extends \PHPUnit_Framework_TestCase
+class AssetFileSizeValidationTest extends TestCase
 {
     public function testFromJsonToJsonSerialization()
     {

--- a/tests/Unit/Field/Validation/AssetImageDimensionsValidationTest.php
+++ b/tests/Unit/Field/Validation/AssetImageDimensionsValidationTest.php
@@ -10,8 +10,9 @@
 namespace Unit\FieldValidation;
 
 use Contentful\Management\Field\Validation\AssetImageDimensionsValidation;
+use PHPUnit\Framework\TestCase;
 
-class AssetImageDimensionsValidationTest extends \PHPUnit_Framework_TestCase
+class AssetImageDimensionsValidationTest extends TestCase
 {
     public function testFromJsonToJsonSerialization()
     {

--- a/tests/Unit/Field/Validation/DateRangeValidationTest.php
+++ b/tests/Unit/Field/Validation/DateRangeValidationTest.php
@@ -10,8 +10,9 @@
 namespace Unit\FieldValidation;
 
 use Contentful\Management\Field\Validation\DateRangeValidation;
+use PHPUnit\Framework\TestCase;
 
-class DateRangeValidationTest extends \PHPUnit_Framework_TestCase
+class DateRangeValidationTest extends TestCase
 {
     public function testFromJsonToJsonSerialization()
     {

--- a/tests/Unit/Field/Validation/InValidationTest.php
+++ b/tests/Unit/Field/Validation/InValidationTest.php
@@ -10,8 +10,9 @@
 namespace Unit\FieldValidation;
 
 use Contentful\Management\Field\Validation\InValidation;
+use PHPUnit\Framework\TestCase;
 
-class InValidationTest extends \PHPUnit_Framework_TestCase
+class InValidationTest extends TestCase
 {
     public function testFromJsonToJsonSerialization()
     {

--- a/tests/Unit/Field/Validation/LinkContentTypeValidationTest.php
+++ b/tests/Unit/Field/Validation/LinkContentTypeValidationTest.php
@@ -10,8 +10,9 @@
 namespace Unit\FieldValidation;
 
 use Contentful\Management\Field\Validation\LinkContentTypeValidation;
+use PHPUnit\Framework\TestCase;
 
-class LinkContentTypeValidationTest extends \PHPUnit_Framework_TestCase
+class LinkContentTypeValidationTest extends TestCase
 {
     public function testFromJsonToJsonSerialization()
     {

--- a/tests/Unit/Field/Validation/LinkMimetypeGroupValidationTest.php
+++ b/tests/Unit/Field/Validation/LinkMimetypeGroupValidationTest.php
@@ -10,8 +10,9 @@
 namespace Unit\FieldValidation;
 
 use Contentful\Management\Field\Validation\LinkMimetypeGroupValidation;
+use PHPUnit\Framework\TestCase;
 
-class LinkMimetypeGroupValidationTest extends \PHPUnit_Framework_TestCase
+class LinkMimetypeGroupValidationTest extends TestCase
 {
     public function testFromJsonToJsonSerialization()
     {

--- a/tests/Unit/Field/Validation/RangeValidationTest.php
+++ b/tests/Unit/Field/Validation/RangeValidationTest.php
@@ -10,8 +10,9 @@
 namespace Unit\FieldValidation;
 
 use Contentful\Management\Field\Validation\RangeValidation;
+use PHPUnit\Framework\TestCase;
 
-class RangeValidationTest extends \PHPUnit_Framework_TestCase
+class RangeValidationTest extends TestCase
 {
     public function testFromJsonToJsonSerialization()
     {

--- a/tests/Unit/Field/Validation/RegexpValidationTest.php
+++ b/tests/Unit/Field/Validation/RegexpValidationTest.php
@@ -10,8 +10,9 @@
 namespace Unit\FieldValidation;
 
 use Contentful\Management\Field\Validation\RegexpValidation;
+use PHPUnit\Framework\TestCase;
 
-class RegexpValidationTest extends \PHPUnit_Framework_TestCase
+class RegexpValidationTest extends TestCase
 {
     public function testFromJsonToJsonSerialization()
     {

--- a/tests/Unit/Field/Validation/SizeValidationTest.php
+++ b/tests/Unit/Field/Validation/SizeValidationTest.php
@@ -10,8 +10,9 @@
 namespace Unit\FieldValidation;
 
 use Contentful\Management\Field\Validation\SizeValidation;
+use PHPUnit\Framework\TestCase;
 
-class SizeValidationTest extends \PHPUnit_Framework_TestCase
+class SizeValidationTest extends TestCase
 {
     public function testFromJsonToJsonSerialization()
     {

--- a/tests/Unit/Field/Validation/UniqueValidationTest.php
+++ b/tests/Unit/Field/Validation/UniqueValidationTest.php
@@ -10,8 +10,9 @@
 namespace Contentful\Tests\Unit\FieldValidation;
 
 use Contentful\Management\Field\Validation\UniqueValidation;
+use PHPUnit\Framework\TestCase;
 
-class UniqueValidationTest extends \PHPUnit_Framework_TestCase
+class UniqueValidationTest extends TestCase
 {
     public function testFromJsonToJsonSerialization()
     {

--- a/tests/Unit/Resource/AssetTest.php
+++ b/tests/Unit/Resource/AssetTest.php
@@ -11,8 +11,9 @@ namespace Contentful\Tests\Unit\Resource;
 
 use Contentful\File\RemoteUploadFile;
 use Contentful\Management\Resource\Asset;
+use PHPUnit\Framework\TestCase;
 
-class AssetTest extends \PHPUnit_Framework_TestCase
+class AssetTest extends TestCase
 {
     public function testGetSetData()
     {

--- a/tests/Unit/Resource/ContentTypeTest.php
+++ b/tests/Unit/Resource/ContentTypeTest.php
@@ -12,8 +12,9 @@ namespace Contentful\Tests\Unit\Resource;
 use Contentful\Management\Field\NumberField;
 use Contentful\Management\Field\SymbolField;
 use Contentful\Management\Resource\ContentType;
+use PHPUnit\Framework\TestCase;
 
-class ContentTypeTest extends \PHPUnit_Framework_TestCase
+class ContentTypeTest extends TestCase
 {
     public function testGetSetData()
     {

--- a/tests/Unit/Resource/EntrySnapshotTest.php
+++ b/tests/Unit/Resource/EntrySnapshotTest.php
@@ -10,8 +10,9 @@
 namespace Contentful\Tests\Unit\Resource;
 
 use Contentful\Management\ResourceBuilder;
+use PHPUnit\Framework\TestCase;
 
-class EntrySnapshotTest extends \PHPUnit_Framework_TestCase
+class EntrySnapshotTest extends TestCase
 {
     public function testJsonSerialize()
     {

--- a/tests/Unit/Resource/EntryTest.php
+++ b/tests/Unit/Resource/EntryTest.php
@@ -11,8 +11,9 @@ namespace Contentful\Tests\Unit\Resource;
 
 use Contentful\Link;
 use Contentful\Management\Resource\Entry;
+use PHPUnit\Framework\TestCase;
 
-class EntryTest extends \PHPUnit_Framework_TestCase
+class EntryTest extends TestCase
 {
     public function testGetSetData()
     {

--- a/tests/Unit/Resource/LocaleTest.php
+++ b/tests/Unit/Resource/LocaleTest.php
@@ -10,8 +10,9 @@
 namespace Contentful\Tests\Unit\Resource;
 
 use Contentful\Management\Resource\Locale;
+use PHPUnit\Framework\TestCase;
 
-class LocaleTest extends \PHPUnit_Framework_TestCase
+class LocaleTest extends TestCase
 {
     public function testGetSetData()
     {

--- a/tests/Unit/Resource/RoleTest.php
+++ b/tests/Unit/Resource/RoleTest.php
@@ -16,8 +16,9 @@ use Contentful\Management\Role\Constraint\NotConstraint;
 use Contentful\Management\Role\Constraint\OrConstraint;
 use Contentful\Management\Role\Permissions;
 use Contentful\Management\Role\Policy;
+use PHPUnit\Framework\TestCase;
 
-class RoleTest extends \PHPUnit_Framework_TestCase
+class RoleTest extends TestCase
 {
     public function testGetSetData()
     {

--- a/tests/Unit/Resource/SpaceTest.php
+++ b/tests/Unit/Resource/SpaceTest.php
@@ -10,8 +10,9 @@
 namespace Contentful\Tests\Unit\Resource;
 
 use Contentful\Management\Resource\Space;
+use PHPUnit\Framework\TestCase;
 
-class SpaceTest extends \PHPUnit_Framework_TestCase
+class SpaceTest extends TestCase
 {
     public function testGetSetData()
     {

--- a/tests/Unit/Resource/WebhookCallDetailsTest.php
+++ b/tests/Unit/Resource/WebhookCallDetailsTest.php
@@ -10,8 +10,9 @@
 namespace Contentful\Tests\Unit\Resource;
 
 use Contentful\Management\ResourceBuilder;
+use PHPUnit\Framework\TestCase;
 
-class WebhookCallDetailsTest extends \PHPUnit_Framework_TestCase
+class WebhookCallDetailsTest extends TestCase
 {
     public function testJsonSerialize()
     {

--- a/tests/Unit/Resource/WebhookCallTest.php
+++ b/tests/Unit/Resource/WebhookCallTest.php
@@ -10,8 +10,9 @@
 namespace Contentful\Tests\Unit\Resource;
 
 use Contentful\Management\ResourceBuilder;
+use PHPUnit\Framework\TestCase;
 
-class WebhookCallTest extends \PHPUnit_Framework_TestCase
+class WebhookCallTest extends TestCase
 {
     public function testJsonSerialize()
     {

--- a/tests/Unit/Resource/WebhookHealthTest.php
+++ b/tests/Unit/Resource/WebhookHealthTest.php
@@ -11,8 +11,9 @@ namespace Contentful\Tests\Unit\Resource;
 
 use Contentful\Management\Resource\WebhookHealth;
 use Contentful\Management\ResourceBuilder;
+use PHPUnit\Framework\TestCase;
 
-class WebhookHealthTest extends \PHPUnit_Framework_TestCase
+class WebhookHealthTest extends TestCase
 {
     public function testJsonSerialize()
     {

--- a/tests/Unit/Resource/WebhookTest.php
+++ b/tests/Unit/Resource/WebhookTest.php
@@ -10,8 +10,9 @@
 namespace Contentful\Tests\Unit\Resource;
 
 use Contentful\Management\Resource\Webhook;
+use PHPUnit\Framework\TestCase;
 
-class WebhookTest extends \PHPUnit_Framework_TestCase
+class WebhookTest extends TestCase
 {
     public function testGetSetData()
     {

--- a/tests/Unit/Role/Constraint/AndConstraintTest.php
+++ b/tests/Unit/Role/Constraint/AndConstraintTest.php
@@ -10,8 +10,9 @@
 namespace Contentful\Tests\Unit\Constraint;
 
 use Contentful\Management\Role\Constraint\AndConstraint;
+use PHPUnit\Framework\TestCase;
 
-class AndConstraintTest extends \PHPUnit_Framework_TestCase
+class AndConstraintTest extends TestCase
 {
     public function testGetSetData()
     {

--- a/tests/Unit/Role/Constraint/EqualityConstraintTest.php
+++ b/tests/Unit/Role/Constraint/EqualityConstraintTest.php
@@ -10,8 +10,9 @@
 namespace Contentful\Tests\Unit\Constraint;
 
 use Contentful\Management\Role\Constraint\EqualityConstraint;
+use PHPUnit\Framework\TestCase;
 
-class EqualityConstraintTest extends \PHPUnit_Framework_TestCase
+class EqualityConstraintTest extends TestCase
 {
     public function testGetSetData()
     {

--- a/tests/Unit/Role/Constraint/NotConstraintTest.php
+++ b/tests/Unit/Role/Constraint/NotConstraintTest.php
@@ -10,8 +10,9 @@
 namespace Contentful\Tests\Unit\Constraint;
 
 use Contentful\Management\Role\Constraint\NotConstraint;
+use PHPUnit\Framework\TestCase;
 
-class NotConstraintTest extends \PHPUnit_Framework_TestCase
+class NotConstraintTest extends TestCase
 {
     public function testGetSetData()
     {

--- a/tests/Unit/Role/Constraint/OrConstraintTest.php
+++ b/tests/Unit/Role/Constraint/OrConstraintTest.php
@@ -10,8 +10,9 @@
 namespace Contentful\Tests\Unit\Constraint;
 
 use Contentful\Management\Role\Constraint\OrConstraint;
+use PHPUnit\Framework\TestCase;
 
-class OrConstraintTest extends \PHPUnit_Framework_TestCase
+class OrConstraintTest extends TestCase
 {
     public function testGetSetData()
     {

--- a/tests/Unit/Role/PermissionsTest.php
+++ b/tests/Unit/Role/PermissionsTest.php
@@ -10,8 +10,9 @@
 namespace Contentful\Tests\Unit;
 
 use Contentful\Management\Role\Permissions;
+use PHPUnit\Framework\TestCase;
 
-class PermissionsTest extends \PHPUnit_Framework_TestCase
+class PermissionsTest extends TestCase
 {
     public function testGetSetData()
     {

--- a/tests/Unit/Role/PolicyTest.php
+++ b/tests/Unit/Role/PolicyTest.php
@@ -11,8 +11,9 @@ namespace Contentful\Tests\Unit;
 
 use Contentful\Management\Role\Constraint\EqualityConstraint;
 use Contentful\Management\Role\Policy;
+use PHPUnit\Framework\TestCase;
 
-class PolicyTest extends \PHPUnit_Framework_TestCase
+class PolicyTest extends TestCase
 {
     public function testGetSetData()
     {

--- a/tests/Unit/SystemPropertiesTest.php
+++ b/tests/Unit/SystemPropertiesTest.php
@@ -10,8 +10,9 @@
 namespace Contentful\Tests\Unit;
 
 use Contentful\Management\SystemProperties;
+use PHPUnit\Framework\TestCase;
 
-class SystemPropertiesTest extends \PHPUnit_Framework_TestCase
+class SystemPropertiesTest extends TestCase
 {
     public function testCreateWithType()
     {


### PR DESCRIPTION
The SDK was previously relying on a globally-installed, old version of PHPUnit.

It was also using an outdated version of `php-vcr/phpunit-testlistener-vcr` (`1.1`). Now we bumped that dependency to `3.0`, which requires PHPUnit 6+. With that, we also include the dependency directly instead of relying on a global test runner, which means that IDEs are now able to correctly handle the dependency.

Most of the changes in files are just replacing `\PHPUnit_Framework_TestCase` with `TestCase` and importing the dependency with `use PHPUnit\Framework\TestCase`.