### PR TITLE
Adds Linkable interface

### DIFF
--- a/src/Management/Behavior/Linkable.php
+++ b/src/Management/Behavior/Linkable.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * This file is part of the contentful-management.php package.
+ *
+ * @copyright 2015-2017 Contentful GmbH
+ * @license   MIT
+ */
+
+namespace Contentful\Management\Behavior;
+
+use Contentful\Link;
+use Contentful\Management\Resource\ResourceInterface;
+
+/**
+ * Linkable interface.
+ *
+ * Represents a resource which can be represented as a Link.
+ *
+ * @see https://www.contentful.com/developers/docs/concepts/links/
+ */
+interface Linkable extends ResourceInterface
+{
+    /**
+     * Creates a Link representation of the current resource.
+     *
+     * @return Link
+     */
+    public function asLink(): Link;
+}

--- a/src/Management/Resource/Asset.php
+++ b/src/Management/Resource/Asset.php
@@ -9,11 +9,13 @@
 
 namespace Contentful\Management\Resource;
 
+use Contentful\Link;
 use Contentful\File\FileInterface;
 use Contentful\File\UnprocessedFileInterface;
 use Contentful\Management\Behavior\Archivable;
 use Contentful\Management\Behavior\Creatable;
 use Contentful\Management\Behavior\Deletable;
+use Contentful\Management\Behavior\Linkable;
 use Contentful\Management\Behavior\Publishable;
 use Contentful\Management\Behavior\Updatable;
 use Contentful\Management\SystemProperties;
@@ -25,7 +27,7 @@ use Contentful\Management\SystemProperties;
  *
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/assets
  */
-class Asset implements SpaceScopedResourceInterface, Publishable, Archivable, Deletable, Updatable, Creatable
+class Asset implements SpaceScopedResourceInterface, Publishable, Archivable, Deletable, Updatable, Creatable, Linkable
 {
     /**
      * @var SystemProperties
@@ -69,6 +71,14 @@ class Asset implements SpaceScopedResourceInterface, Publishable, Archivable, De
     public function getResourceUriPart(): string
     {
         return 'assets';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function asLink(): Link
+    {
+        return new Link($this->sys->getId(), 'Asset');
     }
 
     /**

--- a/src/Management/Resource/ContentType.php
+++ b/src/Management/Resource/ContentType.php
@@ -9,8 +9,10 @@
 
 namespace Contentful\Management\Resource;
 
+use Contentful\Link;
 use Contentful\Management\Behavior\Creatable;
 use Contentful\Management\Behavior\Deletable;
+use Contentful\Management\Behavior\Linkable;
 use Contentful\Management\Behavior\Publishable;
 use Contentful\Management\Behavior\Updatable;
 use Contentful\Management\Field\FieldInterface;
@@ -24,7 +26,7 @@ use Contentful\Management\SystemProperties;
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/content-types
  * @see https://www.contentful.com/developers/docs/concepts/data-model/
  */
-class ContentType implements SpaceScopedResourceInterface, Publishable, Deletable, Updatable, Creatable
+class ContentType implements SpaceScopedResourceInterface, Publishable, Deletable, Updatable, Creatable, Linkable
 {
     /**
      * @var SystemProperties
@@ -76,6 +78,14 @@ class ContentType implements SpaceScopedResourceInterface, Publishable, Deletabl
     public function getResourceUriPart(): string
     {
         return 'content_types';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function asLink(): Link
+    {
+        return new Link($this->sys->getId(), 'ContentType');
     }
 
     /**

--- a/src/Management/Resource/Entry.php
+++ b/src/Management/Resource/Entry.php
@@ -9,10 +9,12 @@
 
 namespace Contentful\Management\Resource;
 
+use Contentful\Link;
 use function Contentful\format_date_for_json;
 use Contentful\Management\Behavior\Archivable;
 use Contentful\Management\Behavior\Creatable;
 use Contentful\Management\Behavior\Deletable;
+use Contentful\Management\Behavior\Linkable;
 use Contentful\Management\Behavior\Publishable;
 use Contentful\Management\Behavior\Updatable;
 use Contentful\Management\SystemProperties;
@@ -24,7 +26,7 @@ use Contentful\Management\SystemProperties;
  *
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/entries
  */
-class Entry implements SpaceScopedResourceInterface, Publishable, Archivable, Deletable, Updatable, Creatable
+class Entry implements SpaceScopedResourceInterface, Publishable, Archivable, Deletable, Updatable, Creatable, Linkable
 {
     /**
      * @var SystemProperties
@@ -60,6 +62,14 @@ class Entry implements SpaceScopedResourceInterface, Publishable, Archivable, De
     public function getResourceUriPart(): string
     {
         return 'entries';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function asLink(): Link
+    {
+        return new Link($this->sys->getId(), 'Entry');
     }
 
     /**

--- a/src/Management/Resource/Role.php
+++ b/src/Management/Resource/Role.php
@@ -9,8 +9,10 @@
 
 namespace Contentful\Management\Resource;
 
+use Contentful\Link;
 use Contentful\Management\Behavior\Creatable;
 use Contentful\Management\Behavior\Deletable;
+use Contentful\Management\Behavior\Linkable;
 use Contentful\Management\Behavior\Updatable;
 use Contentful\Management\Role\Permissions;
 use Contentful\Management\Role\Policy;
@@ -23,7 +25,7 @@ use Contentful\Management\SystemProperties;
  *
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/roles
  */
-class Role implements SpaceScopedResourceInterface, Creatable, Updatable, Deletable
+class Role implements SpaceScopedResourceInterface, Creatable, Updatable, Deletable, Linkable
 {
     /**
      * @var SystemProperties
@@ -78,6 +80,14 @@ class Role implements SpaceScopedResourceInterface, Creatable, Updatable, Deleta
     public function getResourceUriPart(): string
     {
         return 'roles';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function asLink(): Link
+    {
+        return new Link($this->sys->getId(), 'Role');
     }
 
     /**

--- a/src/Management/Resource/Space.php
+++ b/src/Management/Resource/Space.php
@@ -9,6 +9,8 @@
 
 namespace Contentful\Management\Resource;
 
+use Contentful\Link;
+use Contentful\Management\Behavior\Linkable;
 use Contentful\Management\SystemProperties;
 
 /**
@@ -19,7 +21,7 @@ use Contentful\Management\SystemProperties;
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/spaces
  * @see https://www.contentful.com/r/knowledgebase/spaces-and-organizations/
  */
-class Space implements ResourceInterface
+class Space implements ResourceInterface, Linkable
 {
     /**
      * @var string
@@ -48,6 +50,14 @@ class Space implements ResourceInterface
     public function getSystemProperties(): SystemProperties
     {
         return $this->sys;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function asLink(): Link
+    {
+        return new Link($this->sys->getId(), 'Space');
     }
 
     /**

--- a/src/Management/Resource/Upload.php
+++ b/src/Management/Resource/Upload.php
@@ -9,8 +9,10 @@
 
 namespace Contentful\Management\Resource;
 
+use Contentful\Link;
 use Contentful\Management\Behavior\Creatable;
 use Contentful\Management\Behavior\Deletable;
+use Contentful\Management\Behavior\Linkable;
 use Contentful\Management\SystemProperties;
 use Psr\Http\Message\StreamInterface;
 
@@ -21,7 +23,7 @@ use Psr\Http\Message\StreamInterface;
  *
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/uploads
  */
-class Upload implements SpaceScopedResourceInterface, Creatable, Deletable
+class Upload implements SpaceScopedResourceInterface, Creatable, Deletable, Linkable
 {
     /**
      * @var SystemProperties
@@ -62,6 +64,14 @@ class Upload implements SpaceScopedResourceInterface, Creatable, Deletable
     public function getSystemProperties(): SystemProperties
     {
         return $this->sys;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function asLink(): Link
+    {
+        return new Link($this->sys->getId(), 'Upload');
     }
 
     /**

--- a/src/Management/Resource/User.php
+++ b/src/Management/Resource/User.php
@@ -9,6 +9,8 @@
 
 namespace Contentful\Management\Resource;
 
+use Contentful\Link;
+use Contentful\Management\Behavior\Linkable;
 use Contentful\Management\SystemProperties;
 
 /**
@@ -18,7 +20,7 @@ use Contentful\Management\SystemProperties;
  *
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/users/user
  */
-class User implements ResourceInterface
+class User implements ResourceInterface, Linkable
 {
     /**
      * @var SystemProperties
@@ -74,6 +76,14 @@ class User implements ResourceInterface
     public function getSystemProperties(): SystemProperties
     {
         return $this->sys;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function asLink(): Link
+    {
+        return new Link($this->sys->getId(), 'User');
     }
 
     /**

--- a/src/Management/Resource/Webhook.php
+++ b/src/Management/Resource/Webhook.php
@@ -9,8 +9,10 @@
 
 namespace Contentful\Management\Resource;
 
+use Contentful\Link;
 use Contentful\Management\Behavior\Creatable;
 use Contentful\Management\Behavior\Deletable;
+use Contentful\Management\Behavior\Linkable;
 use Contentful\Management\Behavior\Updatable;
 use Contentful\Management\SystemProperties;
 
@@ -21,7 +23,7 @@ use Contentful\Management\SystemProperties;
  *
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/webhooks
  */
-class Webhook implements SpaceScopedResourceInterface, Creatable, Updatable, Deletable
+class Webhook implements SpaceScopedResourceInterface, Creatable, Updatable, Deletable, Linkable
 {
     /**
      * @var SystemProperties
@@ -87,6 +89,14 @@ class Webhook implements SpaceScopedResourceInterface, Creatable, Updatable, Del
     public function getResourceUriPart(): string
     {
         return 'webhook_definitions';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function asLink(): Link
+    {
+        return new Link($this->sys->getId(), 'WebhookDefinition');
     }
 
     /**

--- a/tests/E2E/AssetTest.php
+++ b/tests/E2E/AssetTest.php
@@ -31,6 +31,7 @@ class AssetTest extends End2EndTestCase
         $this->assertEquals('Nyan Cat', $asset->getTitle('en-US'));
         $this->assertNull($asset->getTitle('tlh'));
         $this->assertNull($asset->getDescription('en-US'));
+        $this->assertEquals(new Link('nyancat', 'Asset'), $asset->asLink());
 
         $sys = $asset->getSystemProperties();
         $this->assertEquals('nyancat', $sys->getId());
@@ -169,8 +170,7 @@ class AssetTest extends End2EndTestCase
         $this->assertNotNull($upload->getSystemProperties()->getId());
         $this->assertInstanceOf(\DateTimeImmutable::class, $upload->getSystemProperties()->getExpiresAt());
 
-        $link = new Link($upload->getSystemProperties()->getId(), 'Upload');
-        $uploadFromFile = new LocalUploadFile('contentful.svg', 'image/svg+xml', $link);
+        $uploadFromFile = new LocalUploadFile('contentful.svg', 'image/svg+xml', $upload->asLink());
 
         $asset = new Asset();
         $asset->setTitle('en-US', 'Contentful');

--- a/tests/E2E/ContentTypeTest.php
+++ b/tests/E2E/ContentTypeTest.php
@@ -44,6 +44,7 @@ class ContentTypeTest extends End2EndTestCase
 
         $this->assertEquals('Cat', $contentType->getName());
         $this->assertEquals('Meow.', $contentType->getDescription());
+        $this->assertEquals(new Link('cat', 'ContentType'), $contentType->asLink());
 
         $fields = $contentType->getFields();
         $this->assertCount(8, $fields);

--- a/tests/E2E/EntryTest.php
+++ b/tests/E2E/EntryTest.php
@@ -27,6 +27,7 @@ class EntryTest extends End2EndTestCase
 
         $this->assertEquals('Nyan Cat', $entry->getField('name', 'en-US'));
         $this->assertEquals('Nyan vIghro\'', $entry->getField('name', 'tlh'));
+        $this->assertEquals(new Link('nyancat', 'Entry'), $entry->asLink());
 
         $sys = $entry->getSystemProperties();
         $this->assertEquals('nyancat', $sys->getId());

--- a/tests/E2E/RoleTest.php
+++ b/tests/E2E/RoleTest.php
@@ -9,6 +9,7 @@
 
 namespace Contentful\Tests\E2E;
 
+use Contentful\Link;
 use Contentful\Management\Query;
 use Contentful\Management\Resource\Role;
 use Contentful\Management\Role\Constraint\AndConstraint;
@@ -32,6 +33,7 @@ class RoleTest extends End2EndTestCase
 
         $this->assertEquals('Developer', $role->getName());
         $this->assertEquals('Allows reading Entries and managing API Keys', $role->getDescription());
+        $this->assertEquals(new Link('6khUMmsfVslYd7tRcThTgE', 'Role'), $role->asLink());
 
         $policies = $role->getPolicies();
         $this->assertCount(2, $policies);

--- a/tests/E2E/SpaceTest.php
+++ b/tests/E2E/SpaceTest.php
@@ -26,6 +26,7 @@ class SpaceTest extends End2EndTestCase
         $space = $this->client->getSpace($this->readOnlySpaceId);
 
         $this->assertInstanceOf(Space::class, $space);
+        $this->assertEquals(new Link($this->readOnlySpaceId, 'Space'), $space->asLink());
         $sys = $space->getSystemProperties();
         $this->assertEquals($this->readOnlySpaceId, $sys->getId());
         $this->assertEquals('Space', $sys->getType());

--- a/tests/E2E/UserTest.php
+++ b/tests/E2E/UserTest.php
@@ -9,6 +9,7 @@
 
 namespace Contentful\Tests\E2E;
 
+use Contentful\Link;
 use Contentful\Tests\End2EndTestCase;
 
 class UserTest extends End2EndTestCase
@@ -28,6 +29,7 @@ class UserTest extends End2EndTestCase
         $this->assertEquals(true, $user->isConfirmed());
         $this->assertInternalType('integer', $user->getSignInCount());
         $this->assertGreaterThan(1, $user->getSignInCount());
+        $this->assertEquals(new Link('4Q3e6duhma7V6czH7UXHzE', 'User'), $user->asLink());
         $this->assertEquals('4Q3e6duhma7V6czH7UXHzE', $user->getSystemProperties()->getId());
         $this->assertEquals('User', $user->getSystemProperties()->getType());
 

--- a/tests/E2E/WebhookTest.php
+++ b/tests/E2E/WebhookTest.php
@@ -35,6 +35,7 @@ class WebhookTest extends End2EndTestCase
             'X-Second-Test' => 'Another Value',
         ], $webhook->getHeaders());
         $this->assertEquals(['Entry.auto_save'], $webhook->getTopics());
+        $this->assertEquals(new Link('3tilCowN1lI1rDCe9vhK0C', 'WebhookDefinition'), $webhook->asLink());
 
         $sys = $webhook->getSystemProperties();
         $this->assertEquals(new Link($this->readWriteSpaceId, 'Space'), $sys->getSpace());


### PR DESCRIPTION
A resource implementing the `Linkable` interface can be represented by a `Link` object in Contentful.

The interface contract requires the implementation of a `asLink(): Link` method.

The main uses cases are for `Upload`, `Entry`, and `Asset`, though it has been extended to all possible resources.

Fixes #49 