### PR TITLE
Changes Resource hierarchy

### DIFF
--- a/src/Management/Resource/Asset.php
+++ b/src/Management/Resource/Asset.php
@@ -16,7 +16,6 @@ use Contentful\Management\Behavior\Creatable;
 use Contentful\Management\Behavior\Deletable;
 use Contentful\Management\Behavior\Publishable;
 use Contentful\Management\Behavior\Updatable;
-use Contentful\Management\SystemProperties;
 
 /**
  * Asset class.
@@ -25,13 +24,8 @@ use Contentful\Management\SystemProperties;
  *
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/assets
  */
-class Asset implements SpaceScopedResourceInterface, Publishable, Archivable, Deletable, Updatable, Creatable
+class Asset extends BaseResource implements SpaceScopedResourceInterface, Publishable, Archivable, Deletable, Updatable, Creatable
 {
-    /**
-     * @var SystemProperties
-     */
-    protected $sys;
-
     /**
      * @var string[]
      */
@@ -52,15 +46,7 @@ class Asset implements SpaceScopedResourceInterface, Publishable, Archivable, De
      */
     public function __construct()
     {
-        $this->sys = SystemProperties::withType('Asset');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getSystemProperties(): SystemProperties
-    {
-        return $this->sys;
+        parent::__construct('Asset');
     }
 
     /**

--- a/src/Management/Resource/Asset.php
+++ b/src/Management/Resource/Asset.php
@@ -24,7 +24,7 @@ use Contentful\Management\Behavior\Updatable;
  *
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/assets
  */
-class Asset extends BaseResource implements SpaceScopedResourceInterface, Publishable, Archivable, Deletable, Updatable, Creatable
+class Asset extends BaseResource implements Publishable, Archivable, Deletable, Updatable, Creatable
 {
     /**
      * @var string[]

--- a/src/Management/Resource/BaseResource.php
+++ b/src/Management/Resource/BaseResource.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * This file is part of the contentful-management.php package.
+ *
+ * @copyright 2015-2017 Contentful GmbH
+ * @license   MIT
+ */
+
+namespace Contentful\Management\Resource;
+
+use Contentful\Link;
+use Contentful\Management\SystemProperties;
+
+/**
+ * BaseResource class.
+ */
+abstract class BaseResource implements ResourceInterface
+{
+    /**
+     * @var SystemProperties
+     */
+    protected $sys;
+
+    /**
+     * BaseResource constructor.
+     *
+     * @param string $type The system type
+     * @param array  $sys
+     */
+    protected function __construct(string $type, array $sys = [])
+    {
+        $sys['type'] = $type;
+        $this->sys = new SystemProperties($sys);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSystemProperties(): SystemProperties
+    {
+        return $this->sys;
+    }
+
+    /**
+     * Creates a Link representation of the current resource.
+     *
+     * @return Link
+     */
+    public function asLink(): Link
+    {
+        return new Link($this->sys->getId(), $this->sys->getType());
+    }
+}

--- a/src/Management/Resource/ContentType.php
+++ b/src/Management/Resource/ContentType.php
@@ -23,7 +23,7 @@ use Contentful\Management\Field\FieldInterface;
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/content-types
  * @see https://www.contentful.com/developers/docs/concepts/data-model/
  */
-class ContentType extends BaseResource implements SpaceScopedResourceInterface, Publishable, Deletable, Updatable, Creatable
+class ContentType extends BaseResource implements Publishable, Deletable, Updatable, Creatable
 {
     /**
      * @var string

--- a/src/Management/Resource/ContentType.php
+++ b/src/Management/Resource/ContentType.php
@@ -14,7 +14,6 @@ use Contentful\Management\Behavior\Deletable;
 use Contentful\Management\Behavior\Publishable;
 use Contentful\Management\Behavior\Updatable;
 use Contentful\Management\Field\FieldInterface;
-use Contentful\Management\SystemProperties;
 
 /**
  * ContentType class.
@@ -24,13 +23,8 @@ use Contentful\Management\SystemProperties;
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/content-types
  * @see https://www.contentful.com/developers/docs/concepts/data-model/
  */
-class ContentType implements SpaceScopedResourceInterface, Publishable, Deletable, Updatable, Creatable
+class ContentType extends BaseResource implements SpaceScopedResourceInterface, Publishable, Deletable, Updatable, Creatable
 {
-    /**
-     * @var SystemProperties
-     */
-    protected $sys;
-
     /**
      * @var string
      */
@@ -58,16 +52,8 @@ class ContentType implements SpaceScopedResourceInterface, Publishable, Deletabl
      */
     public function __construct($name)
     {
-        $this->sys = SystemProperties::withType('ContentType');
+        parent::__construct('ContentType');
         $this->name = $name;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getSystemProperties(): SystemProperties
-    {
-        return $this->sys;
     }
 
     /**

--- a/src/Management/Resource/ContentTypeSnapshot.php
+++ b/src/Management/Resource/ContentTypeSnapshot.php
@@ -27,17 +27,9 @@ class ContentTypeSnapshot extends BaseResource implements SpaceScopedResourceInt
     /**
      * ContentTypeSnapshot constructor.
      */
-    public function __construct()
+    final public function __construct()
     {
-        parent::__construct('Snapshot', ['snapshotEntityType' => 'ContentType']);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getResourceUriPart(): string
-    {
-        return 'content_types';
+        throw new \LogicException(sprintf('Class %s can only be instantiated as a result of an API call, manual creation is not allowed.', static::class));
     }
 
     /**

--- a/src/Management/Resource/ContentTypeSnapshot.php
+++ b/src/Management/Resource/ContentTypeSnapshot.php
@@ -17,7 +17,7 @@ namespace Contentful\Management\Resource;
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/snapshots/content-type-snapshots-collection
  * @see https://www.contentful.com/faq/versioning/
  */
-class ContentTypeSnapshot extends BaseResource implements SpaceScopedResourceInterface
+class ContentTypeSnapshot extends BaseResource
 {
     /**
      * @var ContentType

--- a/src/Management/Resource/ContentTypeSnapshot.php
+++ b/src/Management/Resource/ContentTypeSnapshot.php
@@ -9,8 +9,6 @@
 
 namespace Contentful\Management\Resource;
 
-use Contentful\Management\SystemProperties;
-
 /**
  * ContentTypeSnapshot class.
  *
@@ -19,13 +17,8 @@ use Contentful\Management\SystemProperties;
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/snapshots/content-type-snapshots-collection
  * @see https://www.contentful.com/faq/versioning/
  */
-class ContentTypeSnapshot implements SpaceScopedResourceInterface
+class ContentTypeSnapshot extends BaseResource implements SpaceScopedResourceInterface
 {
-    /**
-     * @var SystemProperties
-     */
-    protected $sys;
-
     /**
      * @var ContentType
      */
@@ -36,15 +29,7 @@ class ContentTypeSnapshot implements SpaceScopedResourceInterface
      */
     public function __construct()
     {
-        $this->sys = new SystemProperties(['type' => 'Snapshot', 'snapshotEntityType' => 'ContentType']);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getSystemProperties(): SystemProperties
-    {
-        return $this->sys;
+        parent::__construct('Snapshot', ['snapshotEntityType' => 'ContentType']);
     }
 
     /**

--- a/src/Management/Resource/Entry.php
+++ b/src/Management/Resource/Entry.php
@@ -23,7 +23,7 @@ use Contentful\Management\Behavior\Updatable;
  *
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/entries
  */
-class Entry extends BaseResource implements SpaceScopedResourceInterface, Publishable, Archivable, Deletable, Updatable, Creatable
+class Entry extends BaseResource implements Publishable, Archivable, Deletable, Updatable, Creatable
 {
     /**
      * @var array[]

--- a/src/Management/Resource/Entry.php
+++ b/src/Management/Resource/Entry.php
@@ -15,7 +15,6 @@ use Contentful\Management\Behavior\Creatable;
 use Contentful\Management\Behavior\Deletable;
 use Contentful\Management\Behavior\Publishable;
 use Contentful\Management\Behavior\Updatable;
-use Contentful\Management\SystemProperties;
 
 /**
  * Entry class.
@@ -24,13 +23,8 @@ use Contentful\Management\SystemProperties;
  *
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/entries
  */
-class Entry implements SpaceScopedResourceInterface, Publishable, Archivable, Deletable, Updatable, Creatable
+class Entry extends BaseResource implements SpaceScopedResourceInterface, Publishable, Archivable, Deletable, Updatable, Creatable
 {
-    /**
-     * @var SystemProperties
-     */
-    protected $sys;
-
     /**
      * @var array[]
      */
@@ -43,15 +37,7 @@ class Entry implements SpaceScopedResourceInterface, Publishable, Archivable, De
      */
     public function __construct(string $contentTypeId)
     {
-        $this->sys = new SystemProperties(['type' => 'Entry', 'contentType' => ['sys' => ['id' => $contentTypeId, 'linkType' => 'ContentType']]]);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getSystemProperties(): SystemProperties
-    {
-        return $this->sys;
+        parent::__construct('Entry', ['contentType' => ['sys' => ['id' => $contentTypeId, 'linkType' => 'ContentType']]]);
     }
 
     /**

--- a/src/Management/Resource/EntrySnapshot.php
+++ b/src/Management/Resource/EntrySnapshot.php
@@ -17,7 +17,7 @@ namespace Contentful\Management\Resource;
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/snapshots/entry-snapshots-collection
  * @see https://www.contentful.com/faq/versioning/
  */
-class EntrySnapshot extends BaseResource implements SpaceScopedResourceInterface
+class EntrySnapshot extends BaseResource
 {
     /**
      * @var Entry

--- a/src/Management/Resource/EntrySnapshot.php
+++ b/src/Management/Resource/EntrySnapshot.php
@@ -27,17 +27,9 @@ class EntrySnapshot extends BaseResource implements SpaceScopedResourceInterface
     /**
      * EntrySnapshot constructor.
      */
-    public function __construct()
+    final public function __construct()
     {
-        parent::__construct('Snapshot', ['snapshotEntityType' => 'Entry']);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getResourceUriPart(): string
-    {
-        return 'entries';
+        throw new \LogicException(sprintf('Class %s can only be instantiated as a result of an API call, manual creation is not allowed.', static::class));
     }
 
     /**

--- a/src/Management/Resource/EntrySnapshot.php
+++ b/src/Management/Resource/EntrySnapshot.php
@@ -9,8 +9,6 @@
 
 namespace Contentful\Management\Resource;
 
-use Contentful\Management\SystemProperties;
-
 /**
  * EntrySnapshot class.
  *
@@ -19,13 +17,8 @@ use Contentful\Management\SystemProperties;
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/snapshots/entry-snapshots-collection
  * @see https://www.contentful.com/faq/versioning/
  */
-class EntrySnapshot implements SpaceScopedResourceInterface
+class EntrySnapshot extends BaseResource implements SpaceScopedResourceInterface
 {
-    /**
-     * @var SystemProperties
-     */
-    protected $sys;
-
     /**
      * @var Entry
      */
@@ -36,15 +29,7 @@ class EntrySnapshot implements SpaceScopedResourceInterface
      */
     public function __construct()
     {
-        $this->sys = new SystemProperties(['type' => 'Snapshot', 'snapshotEntityType' => 'Entry']);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getSystemProperties(): SystemProperties
-    {
-        return $this->sys;
+        parent::__construct('Snapshot', ['snapshotEntityType' => 'Entry']);
     }
 
     /**

--- a/src/Management/Resource/Locale.php
+++ b/src/Management/Resource/Locale.php
@@ -12,7 +12,6 @@ namespace Contentful\Management\Resource;
 use Contentful\Management\Behavior\Creatable;
 use Contentful\Management\Behavior\Deletable;
 use Contentful\Management\Behavior\Updatable;
-use Contentful\Management\SystemProperties;
 
 /**
  * Locale class.
@@ -22,13 +21,8 @@ use Contentful\Management\SystemProperties;
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/locales
  * @see https://www.contentful.com/developers/docs/concepts/locales/
  */
-class Locale implements SpaceScopedResourceInterface, Deletable, Updatable, Creatable
+class Locale extends BaseResource implements SpaceScopedResourceInterface, Deletable, Updatable, Creatable
 {
-    /**
-     * @var SystemProperties
-     */
-    protected $sys;
-
     /**
      * @var string
      */
@@ -73,18 +67,10 @@ class Locale implements SpaceScopedResourceInterface, Deletable, Updatable, Crea
      */
     public function __construct(string $name, string $code, string $fallbackCode = null)
     {
-        $this->sys = SystemProperties::withType('Locale');
+        parent::__construct('Locale');
         $this->name = $name;
         $this->code = $code;
         $this->fallbackCode = $fallbackCode;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getSystemProperties(): SystemProperties
-    {
-        return $this->sys;
     }
 
     /**

--- a/src/Management/Resource/Locale.php
+++ b/src/Management/Resource/Locale.php
@@ -21,7 +21,7 @@ use Contentful\Management\Behavior\Updatable;
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/locales
  * @see https://www.contentful.com/developers/docs/concepts/locales/
  */
-class Locale extends BaseResource implements SpaceScopedResourceInterface, Deletable, Updatable, Creatable
+class Locale extends BaseResource implements Deletable, Updatable, Creatable
 {
     /**
      * @var string

--- a/src/Management/Resource/Organization.php
+++ b/src/Management/Resource/Organization.php
@@ -27,9 +27,9 @@ class Organization extends BaseResource
     /**
      * Organization constructor.
      */
-    public function __construct()
+    final public function __construct()
     {
-        parent::__construct('Organization');
+        throw new \LogicException(sprintf('Class %s can only be instantiated as a result of an API call, manual creation is not allowed.', static::class));
     }
 
     /**

--- a/src/Management/Resource/Organization.php
+++ b/src/Management/Resource/Organization.php
@@ -9,8 +9,6 @@
 
 namespace Contentful\Management\Resource;
 
-use Contentful\Management\SystemProperties;
-
 /**
  * Organization class.
  *
@@ -19,13 +17,8 @@ use Contentful\Management\SystemProperties;
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/organizations
  * @see https://www.contentful.com/r/knowledgebase/spaces-and-organizations/
  */
-class Organization implements ResourceInterface
+class Organization extends BaseResource
 {
-    /**
-     * @var SystemProperties
-     */
-    protected $sys;
-
     /**
      * @var string
      */
@@ -36,15 +29,7 @@ class Organization implements ResourceInterface
      */
     public function __construct()
     {
-        $this->sys = SystemProperties::withType('Organization');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getSystemProperties(): SystemProperties
-    {
-        return $this->sys;
+        parent::__construct('Organization');
     }
 
     /**

--- a/src/Management/Resource/PublishedContentType.php
+++ b/src/Management/Resource/PublishedContentType.php
@@ -19,6 +19,14 @@ namespace Contentful\Management\Resource;
 class PublishedContentType extends ContentType
 {
     /**
+     * PublishedContentType constructor.
+     */
+    final public function __construct()
+    {
+        throw new \LogicException(sprintf('Class %s can only be instantiated as a result of an API call, manual creation is not allowed.', static::class));
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function isPublished(): bool

--- a/src/Management/Resource/Role.php
+++ b/src/Management/Resource/Role.php
@@ -22,7 +22,7 @@ use Contentful\Management\Role\Policy;
  *
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/roles
  */
-class Role extends BaseResource implements SpaceScopedResourceInterface, Creatable, Updatable, Deletable
+class Role extends BaseResource implements Creatable, Updatable, Deletable
 {
     /**
      * @var string

--- a/src/Management/Resource/Role.php
+++ b/src/Management/Resource/Role.php
@@ -14,7 +14,6 @@ use Contentful\Management\Behavior\Deletable;
 use Contentful\Management\Behavior\Updatable;
 use Contentful\Management\Role\Permissions;
 use Contentful\Management\Role\Policy;
-use Contentful\Management\SystemProperties;
 
 /**
  * Role class.
@@ -23,13 +22,8 @@ use Contentful\Management\SystemProperties;
  *
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/roles
  */
-class Role implements SpaceScopedResourceInterface, Creatable, Updatable, Deletable
+class Role extends BaseResource implements SpaceScopedResourceInterface, Creatable, Updatable, Deletable
 {
-    /**
-     * @var SystemProperties
-     */
-    protected $sys;
-
     /**
      * @var string
      */
@@ -58,18 +52,10 @@ class Role implements SpaceScopedResourceInterface, Creatable, Updatable, Deleta
      */
     public function __construct(string $name = '', string $description = '')
     {
-        $this->sys = SystemProperties::withType('Role');
+        parent::__construct('Role');
         $this->name = $name;
         $this->description = $description;
         $this->permissions = new Permissions();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getSystemProperties(): SystemProperties
-    {
-        return $this->sys;
     }
 
     /**

--- a/src/Management/Resource/Space.php
+++ b/src/Management/Resource/Space.php
@@ -9,8 +9,6 @@
 
 namespace Contentful\Management\Resource;
 
-use Contentful\Management\SystemProperties;
-
 /**
  * Space class.
  *
@@ -19,17 +17,12 @@ use Contentful\Management\SystemProperties;
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/spaces
  * @see https://www.contentful.com/r/knowledgebase/spaces-and-organizations/
  */
-class Space implements ResourceInterface
+class Space extends BaseResource
 {
     /**
      * @var string
      */
     protected $name;
-
-    /**
-     * @var SystemProperties
-     */
-    protected $sys;
 
     /**
      * Space constructor.
@@ -38,16 +31,8 @@ class Space implements ResourceInterface
      */
     public function __construct(string $name)
     {
+        parent::__construct('Space');
         $this->name = $name;
-        $this->sys = SystemProperties::withType('Space');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getSystemProperties(): SystemProperties
-    {
-        return $this->sys;
     }
 
     /**

--- a/src/Management/Resource/SpaceScopedResourceInterface.php
+++ b/src/Management/Resource/SpaceScopedResourceInterface.php
@@ -13,6 +13,8 @@ namespace Contentful\Management\Resource;
  * SpaceScopedResourceInterface.
  *
  * Represents a resource which is scoped to a Contentful space.
+ * This interface should not be directly implemented by any class.
+ * Its main use is to be extended by another interface.
  *
  * @see https://www.contentful.com/r/knowledgebase/spaces-and-organizations/
  */

--- a/src/Management/Resource/Upload.php
+++ b/src/Management/Resource/Upload.php
@@ -20,7 +20,7 @@ use Psr\Http\Message\StreamInterface;
  *
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/uploads
  */
-class Upload extends BaseResource implements SpaceScopedResourceInterface, Creatable, Deletable
+class Upload extends BaseResource implements Creatable, Deletable
 {
     /**
      * @var string|resource|StreamInterface|null

--- a/src/Management/Resource/Upload.php
+++ b/src/Management/Resource/Upload.php
@@ -11,7 +11,6 @@ namespace Contentful\Management\Resource;
 
 use Contentful\Management\Behavior\Creatable;
 use Contentful\Management\Behavior\Deletable;
-use Contentful\Management\SystemProperties;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -21,13 +20,8 @@ use Psr\Http\Message\StreamInterface;
  *
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/uploads
  */
-class Upload implements SpaceScopedResourceInterface, Creatable, Deletable
+class Upload extends BaseResource implements SpaceScopedResourceInterface, Creatable, Deletable
 {
-    /**
-     * @var SystemProperties
-     */
-    protected $sys;
-
     /**
      * @var string|resource|StreamInterface|null
      */
@@ -44,7 +38,7 @@ class Upload implements SpaceScopedResourceInterface, Creatable, Deletable
      */
     public function __construct($body)
     {
-        $this->sys = SystemProperties::withType('Upload');
+        parent::__construct('Upload');
         $this->body = $body;
     }
 
@@ -54,14 +48,6 @@ class Upload implements SpaceScopedResourceInterface, Creatable, Deletable
     public function getResourceUriPart(): string
     {
         return 'uploads';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getSystemProperties(): SystemProperties
-    {
-        return $this->sys;
     }
 
     /**

--- a/src/Management/Resource/User.php
+++ b/src/Management/Resource/User.php
@@ -9,8 +9,6 @@
 
 namespace Contentful\Management\Resource;
 
-use Contentful\Management\SystemProperties;
-
 /**
  * User class.
  *
@@ -18,13 +16,8 @@ use Contentful\Management\SystemProperties;
  *
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/users/user
  */
-class User implements ResourceInterface
+class User extends BaseResource
 {
-    /**
-     * @var SystemProperties
-     */
-    protected $sys;
-
     /**
      * @var string
      */
@@ -65,15 +58,7 @@ class User implements ResourceInterface
      */
     public function __construct()
     {
-        $this->sys = SystemProperties::withType('User');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getSystemProperties(): SystemProperties
-    {
-        return $this->sys;
+        parent::__construct('User');
     }
 
     /**

--- a/src/Management/Resource/User.php
+++ b/src/Management/Resource/User.php
@@ -56,9 +56,9 @@ class User extends BaseResource
     /**
      * User constructor.
      */
-    public function __construct()
+    final public function __construct()
     {
-        parent::__construct('User');
+        throw new \LogicException(sprintf('Class %s can only be instantiated as a result of an API call, manual creation is not allowed.', static::class));
     }
 
     /**

--- a/src/Management/Resource/Webhook.php
+++ b/src/Management/Resource/Webhook.php
@@ -20,7 +20,7 @@ use Contentful\Management\Behavior\Updatable;
  *
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/webhooks
  */
-class Webhook extends BaseResource implements SpaceScopedResourceInterface, Creatable, Updatable, Deletable
+class Webhook extends BaseResource implements Creatable, Updatable, Deletable
 {
     /**
      * @var string

--- a/src/Management/Resource/Webhook.php
+++ b/src/Management/Resource/Webhook.php
@@ -12,7 +12,6 @@ namespace Contentful\Management\Resource;
 use Contentful\Management\Behavior\Creatable;
 use Contentful\Management\Behavior\Deletable;
 use Contentful\Management\Behavior\Updatable;
-use Contentful\Management\SystemProperties;
 
 /**
  * Webhook class.
@@ -21,13 +20,8 @@ use Contentful\Management\SystemProperties;
  *
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/webhooks
  */
-class Webhook implements SpaceScopedResourceInterface, Creatable, Updatable, Deletable
+class Webhook extends BaseResource implements SpaceScopedResourceInterface, Creatable, Updatable, Deletable
 {
-    /**
-     * @var SystemProperties
-     */
-    protected $sys;
-
     /**
      * @var string
      */
@@ -67,18 +61,10 @@ class Webhook implements SpaceScopedResourceInterface, Creatable, Updatable, Del
      */
     public function __construct(string $name, string $url, array $topics = [])
     {
-        $this->sys = SystemProperties::withType('WebhookDefinition');
+        parent::__construct('WebhookDefinition');
         $this->name = $name;
         $this->url = $url;
         $this->setTopics($topics);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getSystemProperties(): SystemProperties
-    {
-        return $this->sys;
     }
 
     /**

--- a/src/Management/Resource/WebhookCall.php
+++ b/src/Management/Resource/WebhookCall.php
@@ -18,7 +18,7 @@ use function Contentful\format_date_for_json;
  *
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/webhook-calls/webhook-call-overview
  */
-class WebhookCall extends BaseResource implements SpaceScopedResourceInterface
+class WebhookCall extends BaseResource
 {
     /**
      * @var int

--- a/src/Management/Resource/WebhookCall.php
+++ b/src/Management/Resource/WebhookCall.php
@@ -53,17 +53,9 @@ class WebhookCall extends BaseResource implements SpaceScopedResourceInterface
     /**
      * WebhookCallOverview constructor.
      */
-    public function __construct()
+    final public function __construct()
     {
-        parent::__construct('WebhookCallOverview');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getResourceUriPart(): string
-    {
-        return 'webhooks';
+        throw new \LogicException(sprintf('Class %s can only be instantiated as a result of an API call, manual creation is not allowed.', static::class));
     }
 
     /**

--- a/src/Management/Resource/WebhookCall.php
+++ b/src/Management/Resource/WebhookCall.php
@@ -10,7 +10,6 @@
 namespace Contentful\Management\Resource;
 
 use function Contentful\format_date_for_json;
-use Contentful\Management\SystemProperties;
 
 /**
  * WebhookCall class.
@@ -19,13 +18,8 @@ use Contentful\Management\SystemProperties;
  *
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/webhook-calls/webhook-call-overview
  */
-class WebhookCall implements SpaceScopedResourceInterface
+class WebhookCall extends BaseResource implements SpaceScopedResourceInterface
 {
-    /**
-     * @var SystemProperties
-     */
-    protected $sys;
-
     /**
      * @var int
      */
@@ -61,15 +55,7 @@ class WebhookCall implements SpaceScopedResourceInterface
      */
     public function __construct()
     {
-        $this->sys = SystemProperties::withType('WebhookCallOverview');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getSystemProperties(): SystemProperties
-    {
-        return $this->sys;
+        parent::__construct('WebhookCallOverview');
     }
 
     /**

--- a/src/Management/Resource/WebhookCallDetails.php
+++ b/src/Management/Resource/WebhookCallDetails.php
@@ -20,7 +20,7 @@ use GuzzleHttp\Psr7\Response;
  *
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/webhook-calls/webhook-call-details
  */
-class WebhookCallDetails extends BaseResource implements SpaceScopedResourceInterface
+class WebhookCallDetails extends BaseResource
 {
     /**
      * @var Request

--- a/src/Management/Resource/WebhookCallDetails.php
+++ b/src/Management/Resource/WebhookCallDetails.php
@@ -10,7 +10,6 @@
 namespace Contentful\Management\Resource;
 
 use function Contentful\format_date_for_json;
-use Contentful\Management\SystemProperties;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 
@@ -21,13 +20,8 @@ use GuzzleHttp\Psr7\Response;
  *
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/webhook-calls/webhook-call-details
  */
-class WebhookCallDetails implements SpaceScopedResourceInterface
+class WebhookCallDetails extends BaseResource implements SpaceScopedResourceInterface
 {
-    /**
-     * @var SystemProperties
-     */
-    protected $sys;
-
     /**
      * @var Request
      */
@@ -73,15 +67,7 @@ class WebhookCallDetails implements SpaceScopedResourceInterface
      */
     public function __construct()
     {
-        $this->sys = SystemProperties::withType('WebhookCallDetails');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getSystemProperties(): SystemProperties
-    {
-        return $this->sys;
+        parent::__construct('WebhookCallDetails');
     }
 
     /**

--- a/src/Management/Resource/WebhookCallDetails.php
+++ b/src/Management/Resource/WebhookCallDetails.php
@@ -65,17 +65,9 @@ class WebhookCallDetails extends BaseResource implements SpaceScopedResourceInte
     /**
      * WebhookCallDetails constructor.
      */
-    public function __construct()
+    final public function __construct()
     {
-        parent::__construct('WebhookCallDetails');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getResourceUriPart(): string
-    {
-        return 'webhooks';
+        throw new \LogicException(sprintf('Class %s can only be instantiated as a result of an API call, manual creation is not allowed.', static::class));
     }
 
     /**

--- a/src/Management/Resource/WebhookHealth.php
+++ b/src/Management/Resource/WebhookHealth.php
@@ -31,17 +31,9 @@ class WebhookHealth extends BaseResource implements SpaceScopedResourceInterface
     /**
      * WebhookHealth constructor.
      */
-    public function __construct()
+    final public function __construct()
     {
-        parent::__construct('Webhook');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getResourceUriPart(): string
-    {
-        return 'webhooks';
+        throw new \LogicException(sprintf('Class %s can only be instantiated as a result of an API call, manual creation is not allowed.', static::class));
     }
 
     /**

--- a/src/Management/Resource/WebhookHealth.php
+++ b/src/Management/Resource/WebhookHealth.php
@@ -16,7 +16,7 @@ namespace Contentful\Management\Resource;
  *
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/webhook-calls/webhook-health
  */
-class WebhookHealth extends BaseResource implements SpaceScopedResourceInterface
+class WebhookHealth extends BaseResource
 {
     /**
      * @var int

--- a/src/Management/Resource/WebhookHealth.php
+++ b/src/Management/Resource/WebhookHealth.php
@@ -9,8 +9,6 @@
 
 namespace Contentful\Management\Resource;
 
-use Contentful\Management\SystemProperties;
-
 /**
  * WebhookHealth class.
  *
@@ -18,13 +16,8 @@ use Contentful\Management\SystemProperties;
  *
  * @see https://www.contentful.com/developers/docs/references/content-management-api/#/reference/webhook-calls/webhook-health
  */
-class WebhookHealth implements SpaceScopedResourceInterface
+class WebhookHealth extends BaseResource implements SpaceScopedResourceInterface
 {
-    /**
-     * @var SystemProperties
-     */
-    protected $sys;
-
     /**
      * @var int
      */
@@ -40,15 +33,7 @@ class WebhookHealth implements SpaceScopedResourceInterface
      */
     public function __construct()
     {
-        $this->sys = SystemProperties::withType('Webhook');
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getSystemProperties(): SystemProperties
-    {
-        return $this->sys;
+        parent::__construct('Webhook');
     }
 
     /**

--- a/tests/E2E/AssetTest.php
+++ b/tests/E2E/AssetTest.php
@@ -31,6 +31,7 @@ class AssetTest extends End2EndTestCase
         $this->assertEquals('Nyan Cat', $asset->getTitle('en-US'));
         $this->assertNull($asset->getTitle('tlh'));
         $this->assertNull($asset->getDescription('en-US'));
+        $this->assertEquals(new Link('nyancat', 'Asset'), $asset->asLink());
 
         $sys = $asset->getSystemProperties();
         $this->assertEquals('nyancat', $sys->getId());
@@ -166,11 +167,11 @@ class AssetTest extends End2EndTestCase
         // Creates upload using string
         $upload = new Upload(file_get_contents(__DIR__.'/../fixtures/contentful-name.svg'));
         $manager->create($upload);
+        $this->assertEquals(new Link($upload->getSystemProperties()->getId(), 'Upload'), $upload->asLink());
         $this->assertNotNull($upload->getSystemProperties()->getId());
         $this->assertInstanceOf(\DateTimeImmutable::class, $upload->getSystemProperties()->getExpiresAt());
 
-        $link = new Link($upload->getSystemProperties()->getId(), 'Upload');
-        $uploadFromFile = new LocalUploadFile('contentful.svg', 'image/svg+xml', $link);
+        $uploadFromFile = new LocalUploadFile('contentful.svg', 'image/svg+xml', $upload->asLink());
 
         $asset = new Asset();
         $asset->setTitle('en-US', 'Contentful');

--- a/tests/E2E/AssetTest.php
+++ b/tests/E2E/AssetTest.php
@@ -46,9 +46,6 @@ class AssetTest extends End2EndTestCase
         $this->assertEquals(1, $sys->getPublishedCounter());
         $this->assertEquals(new \DateTimeImmutable('2013-09-02T14:56:34.24'), $sys->getPublishedAt());
         $this->assertEquals(new \DateTimeImmutable('2013-09-02T14:56:34.24'), $sys->getFirstPublishedAt());
-
-        $json = '{"fields":{"title":{"en-US":"Nyan Cat"},"file":{"en-US":{"fileName":"Nyan_cat_250px_frame.png","contentType":"image\/png","details":{"image":{"width": 250,"height": 250},"size": 12273},"url":"\/\/images.contentful.com\/cfexampleapi\/4gp6taAwW4CmSgumq2ekUm\/9da0cd1936871b8d72343e895a00d611\/Nyan_cat_250px_frame.png"}}},"sys":{"id": "nyancat","type": "Asset","space":{"sys":{"type":"Link","linkType": "Space", "id":"cfexampleapi"}},"createdAt":"2013-09-02T14:54:17.868Z","createdBy":{"sys":{"type": "Link","linkType":"User","id": "7BslKh9TdKGOK41VmLDjFZ"}},"firstPublishedAt": "2013-09-02T14:56:34.240Z","publishedCounter": 1,"publishedAt":"2013-09-02T14:56:34.240Z","publishedBy":{"sys":{"type": "Link","linkType": "User","id":"7BslKh9TdKGOK41VmLDjFZ"}},"publishedVersion": 1,"version": 2,"updatedAt":"2013-09-02T14:56:34.264Z","updatedBy":{"sys":{"type":"Link","linkType": "User","id": "7BslKh9TdKGOK41VmLDjFZ"}}}}';
-        $this->assertJsonStringEqualsJsonString($json, json_encode($asset));
     }
 
     /**

--- a/tests/E2E/ContentTypeTest.php
+++ b/tests/E2E/ContentTypeTest.php
@@ -44,6 +44,8 @@ class ContentTypeTest extends End2EndTestCase
 
         $this->assertEquals('Cat', $contentType->getName());
         $this->assertEquals('Meow.', $contentType->getDescription());
+        $this->assertEquals(new Link('cat', 'ContentType'), $contentType->asLink());
+        $this->assertEquals(false, $contentType->isPublished());
 
         $fields = $contentType->getFields();
         $this->assertCount(8, $fields);

--- a/tests/E2E/EntryTest.php
+++ b/tests/E2E/EntryTest.php
@@ -27,6 +27,7 @@ class EntryTest extends End2EndTestCase
 
         $this->assertEquals('Nyan Cat', $entry->getField('name', 'en-US'));
         $this->assertEquals('Nyan vIghro\'', $entry->getField('name', 'tlh'));
+        $this->assertEquals(new Link('nyancat', 'Entry'), $entry->asLink());
 
         $sys = $entry->getSystemProperties();
         $this->assertEquals('nyancat', $sys->getId());

--- a/tests/E2E/LocaleTest.php
+++ b/tests/E2E/LocaleTest.php
@@ -41,8 +41,6 @@ class LocaleTest extends End2EndTestCase
         $this->assertEquals(new \DateTimeImmutable('2013-06-25T12:13:56'), $sys->getUpdatedAt());
         $this->assertEquals(new Link('7BslKh9TdKGOK41VmLDjFZ', 'User'), $sys->getCreatedBy());
         $this->assertEquals(new Link('7BslKh9TdKGOK41VmLDjFZ', 'User'), $sys->getUpdatedBy());
-
-        $this->assertJsonStringEqualsJsonString('{"name":"English","code":"en-US","fallbackCode":null,"contentManagementApi":true,"contentDeliveryApi":true,"optional":false,"sys":{"type":"Locale","id":"2oQPjMCL9bQkylziydLh57","version":1,"space":{"sys":{"type":"Link","linkType":"Space","id":"cfexampleapi"}},"createdBy":{"sys":{"type":"Link","linkType":"User","id":"7BslKh9TdKGOK41VmLDjFZ"}},"createdAt":"2013-06-23T19:02:00Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"7BslKh9TdKGOK41VmLDjFZ"}},"updatedAt":"2013-06-25T12:13:56Z"}}', json_encode($locale));
     }
 
     /**

--- a/tests/E2E/LocaleTest.php
+++ b/tests/E2E/LocaleTest.php
@@ -23,6 +23,7 @@ class LocaleTest extends End2EndTestCase
         $manager = $this->getReadOnlySpaceManager();
 
         $locale = $manager->getLocale('2oQPjMCL9bQkylziydLh57');
+        $this->assertEquals(new Link('2oQPjMCL9bQkylziydLh57', 'Locale'), $locale->asLink());
         $this->assertEquals('English', $locale->getName());
         $this->assertEquals('en-US', $locale->getCode());
         $this->assertNull($locale->getFallbackCode());

--- a/tests/E2E/OrganizationTest.php
+++ b/tests/E2E/OrganizationTest.php
@@ -34,8 +34,6 @@ class OrganizationTest extends End2EndTestCase
         $this->assertEquals(1, $sys->getVersion());
         $this->assertEquals(new \DateTimeImmutable('2017-07-12T13:04:54'), $sys->getCreatedAt());
         $this->assertEquals(new \DateTimeImmutable('2017-07-13T09:35:27'), $sys->getUpdatedAt());
-
-        $this->assertJsonStringEqualsJsonString('{"sys":{"id":"4Q3Lza73mxcjmluLU7V5EG","type":"Organization","createdAt":"2017-07-12T13:04:54Z","updatedAt":"2017-07-13T09:35:27Z","version":1},"name":"Contentful PHP SDK Testing"}', json_encode($organization));
     }
 
     /**

--- a/tests/E2E/OrganizationTest.php
+++ b/tests/E2E/OrganizationTest.php
@@ -9,6 +9,7 @@
 
 namespace Contentful\Tests\E2E;
 
+use Contentful\Link;
 use Contentful\Management\Query;
 use Contentful\Tests\End2EndTestCase;
 
@@ -29,6 +30,7 @@ class OrganizationTest extends End2EndTestCase
         $sys = $organization->getSystemProperties();
         $this->assertEquals('Organization', $sys->getType());
         $this->assertEquals('4Q3Lza73mxcjmluLU7V5EG', $sys->getId());
+        $this->assertEquals(new Link('4Q3Lza73mxcjmluLU7V5EG', 'Organization'), $organization->asLink());
         $this->assertEquals(1, $sys->getVersion());
         $this->assertEquals(new \DateTimeImmutable('2017-07-12T13:04:54'), $sys->getCreatedAt());
         $this->assertEquals(new \DateTimeImmutable('2017-07-13T09:35:27'), $sys->getUpdatedAt());

--- a/tests/E2E/PublishedContentTypeTest.php
+++ b/tests/E2E/PublishedContentTypeTest.php
@@ -26,6 +26,8 @@ class PublishedContentTypeTest extends End2EndTestCase
 
         $this->assertEquals('Cat', $contentType->getName());
         $this->assertEquals('name', $contentType->getDisplayField());
+        $this->assertEquals(new Link('cat', 'ContentType'), $contentType->asLink());
+        $this->assertEquals(true, $contentType->isPublished());
         $this->assertCount(8, $contentType->getFields());
 
         $sys = $contentType->getSystemProperties();

--- a/tests/E2E/PublishedContentTypeTest.php
+++ b/tests/E2E/PublishedContentTypeTest.php
@@ -37,9 +37,6 @@ class PublishedContentTypeTest extends End2EndTestCase
         $this->assertEquals(new \DateTimeImmutable('2017-07-06T09:58:52.691'), $sys->getUpdatedAt());
         $this->assertEquals(new Link($this->readOnlySpaceId, 'Space'), $sys->getSpace());
         $this->assertEquals(8, $sys->getRevision());
-
-        $json = '{"sys": {"space": {"sys": {"type": "Link","linkType": "Space","id": "cfexampleapi"}},"id": "cat","type": "ContentType","createdAt": "2013-06-27T22:46:12.852Z","updatedAt": "2017-07-06T09:58:52.691Z","revision": 8},"displayField": "name","name": "Cat","description": "Meow.","fields": [{"id": "name","name": "Name","type": "Text","localized": true,"required": true,"validations": [{"size": {"min": 3}}],"disabled": false,"omitted": false},{"id": "likes","name": "Likes","type": "Array","localized": false,"required": false,"disabled": false,"omitted": false,"items": {"type": "Symbol"}},{"id": "color","name": "Color","type": "Symbol","localized": false,"required": false,"disabled": false,"omitted": false},{"id": "bestFriend","name": "Best Friend","type": "Link","localized": false,"required": false,"disabled": false,"omitted": false,"linkType": "Entry"},{"id": "birthday","name": "Birthday","type": "Date","localized": false,"required": false,"disabled": false,"omitted": false},{"id": "lifes","name": "Lifes left","type": "Integer","localized": false,"required": false,"disabled": true,"omitted": false},{"id": "lives","name": "Lives left","type": "Integer","localized": false,"required": false,"disabled": false,"omitted": false},{"id": "image","name": "Image","type": "Link","localized": false,"required": false,"disabled": false,"omitted": false,"linkType": "Asset"}]}';
-        $this->assertJsonStringEqualsJsonString($json, json_encode($contentType));
     }
 
     /**

--- a/tests/E2E/RoleTest.php
+++ b/tests/E2E/RoleTest.php
@@ -9,6 +9,7 @@
 
 namespace Contentful\Tests\E2E;
 
+use Contentful\Link;
 use Contentful\Management\Query;
 use Contentful\Management\Resource\Role;
 use Contentful\Management\Role\Constraint\AndConstraint;
@@ -32,6 +33,7 @@ class RoleTest extends End2EndTestCase
 
         $this->assertEquals('Developer', $role->getName());
         $this->assertEquals('Allows reading Entries and managing API Keys', $role->getDescription());
+        $this->assertEquals(new Link('6khUMmsfVslYd7tRcThTgE', 'Role'), $role->asLink());
 
         $policies = $role->getPolicies();
         $this->assertCount(2, $policies);

--- a/tests/E2E/SnapshotTest.php
+++ b/tests/E2E/SnapshotTest.php
@@ -25,6 +25,7 @@ class SnapshotTest extends End2EndTestCase
         $manager = $this->getReadWriteSpaceManager();
 
         $snapshot = $manager->getEntrySnapshot('3LM5FlCdGUIM0Miqc664q6', '3omuk8H8M8wUuqHhxddXtp');
+        $this->assertEquals(new Link('3omuk8H8M8wUuqHhxddXtp', 'Snapshot'), $snapshot->asLink());
         $this->assertInstanceOf(EntrySnapshot::class, $snapshot);
         $entry = $snapshot->getEntry();
         $this->assertEquals('Josh Lyman', $entry->getField('name', 'en-US'));
@@ -67,6 +68,7 @@ class SnapshotTest extends End2EndTestCase
 
         $snapshot = $manager->getContentTypeSnapshot('versionedContentType', '1Qvx64r3Nq0MOtftdcAXJO');
 
+        $this->assertEquals(new Link('1Qvx64r3Nq0MOtftdcAXJO', 'Snapshot'), $snapshot->asLink());
         $contentType = $snapshot->getContentType();
         $this->assertEquals('Versioned Content Type', $contentType->getName());
         $this->assertEquals('title', $contentType->getDisplayField());

--- a/tests/E2E/SpaceTest.php
+++ b/tests/E2E/SpaceTest.php
@@ -26,6 +26,7 @@ class SpaceTest extends End2EndTestCase
         $space = $this->client->getSpace($this->readOnlySpaceId);
 
         $this->assertInstanceOf(Space::class, $space);
+        $this->assertEquals(new Link($this->readOnlySpaceId, 'Space'), $space->asLink());
         $sys = $space->getSystemProperties();
         $this->assertEquals($this->readOnlySpaceId, $sys->getId());
         $this->assertEquals('Space', $sys->getType());

--- a/tests/E2E/SpaceTest.php
+++ b/tests/E2E/SpaceTest.php
@@ -36,9 +36,6 @@ class SpaceTest extends End2EndTestCase
         $this->assertEquals(new Link('7BslKh9TdKGOK41VmLDjFZ', 'User'), $sys->getCreatedBy());
         $this->assertEquals(new Link('7BslKh9TdKGOK41VmLDjFZ', 'User'), $sys->getUpdatedBy());
         $this->assertEquals('Contentful Example API', $space->getName());
-
-        $json = '{"name":"Contentful Example API","sys":{"type":"Space","id":"cfexampleapi","version":4,"createdBy":{"sys":{"type":"Link","linkType":"User","id":"7BslKh9TdKGOK41VmLDjFZ"}},"createdAt":"2013-06-23T19:02:00Z","updatedBy":{"sys":{"type":"Link","linkType":"User","id":"7BslKh9TdKGOK41VmLDjFZ"}},"updatedAt":"2016-02-25T09:57:25Z"}}';
-        $this->assertJsonStringEqualsJsonString($json, json_encode($space));
     }
 
     /**

--- a/tests/E2E/UserTest.php
+++ b/tests/E2E/UserTest.php
@@ -32,7 +32,5 @@ class UserTest extends End2EndTestCase
         $this->assertEquals('4Q3e6duhma7V6czH7UXHzE', $user->getSystemProperties()->getId());
         $this->assertEquals(new Link('4Q3e6duhma7V6czH7UXHzE', 'User'), $user->asLink());
         $this->assertEquals('User', $user->getSystemProperties()->getType());
-
-        $this->assertJsonStringEqualsJsonString('{"firstName":"PHP SDK","lastName":"Tests","avatarUrl":"https:\/\/www.gravatar.com\/avatar\/6474b043cb2a58f34b0576ccf83d56e2?s=50&d=https%3A%2F%2Fstatic.contentful.com%2Fgatekeeper%2Fusers%2Fdefault-43783205a36955c723acfe0a32bcf72eebe709cac2067249bc80385b78ccc70d.png","email":"cidevdocs+php@contentful.com","activated":true,"signInCount":2,"confirmed":true,"sys":{"type":"User","id":"4Q3e6duhma7V6czH7UXHzE","version":3,"createdAt":"2017-07-12T13:04:54Z","updatedAt":"2017-07-12T13:21:26Z"}}', json_encode($user));
     }
 }

--- a/tests/E2E/UserTest.php
+++ b/tests/E2E/UserTest.php
@@ -9,6 +9,7 @@
 
 namespace Contentful\Tests\E2E;
 
+use Contentful\Link;
 use Contentful\Tests\End2EndTestCase;
 
 class UserTest extends End2EndTestCase
@@ -29,6 +30,7 @@ class UserTest extends End2EndTestCase
         $this->assertInternalType('integer', $user->getSignInCount());
         $this->assertGreaterThan(1, $user->getSignInCount());
         $this->assertEquals('4Q3e6duhma7V6czH7UXHzE', $user->getSystemProperties()->getId());
+        $this->assertEquals(new Link('4Q3e6duhma7V6czH7UXHzE', 'User'), $user->asLink());
         $this->assertEquals('User', $user->getSystemProperties()->getType());
 
         $this->assertJsonStringEqualsJsonString('{"firstName":"PHP SDK","lastName":"Tests","avatarUrl":"https:\/\/www.gravatar.com\/avatar\/6474b043cb2a58f34b0576ccf83d56e2?s=50&d=https%3A%2F%2Fstatic.contentful.com%2Fgatekeeper%2Fusers%2Fdefault-43783205a36955c723acfe0a32bcf72eebe709cac2067249bc80385b78ccc70d.png","email":"cidevdocs+php@contentful.com","activated":true,"signInCount":2,"confirmed":true,"sys":{"type":"User","id":"4Q3e6duhma7V6czH7UXHzE","version":3,"createdAt":"2017-07-12T13:04:54Z","updatedAt":"2017-07-12T13:21:26Z"}}', json_encode($user));

--- a/tests/E2E/WebhookTest.php
+++ b/tests/E2E/WebhookTest.php
@@ -27,6 +27,7 @@ class WebhookTest extends End2EndTestCase
 
         $webhook = $manager->getWebhook('3tilCowN1lI1rDCe9vhK0C');
 
+        $this->assertEquals(new Link('3tilCowN1lI1rDCe9vhK0C', 'WebhookDefinition'), $webhook->asLink());
         $this->assertEquals('Default Webhook', $webhook->getName());
         $this->assertEquals('https://www.example.com/default-webhook', $webhook->getUrl());
         $this->assertEquals('default_username', $webhook->getHttpBasicUsername());
@@ -60,9 +61,11 @@ class WebhookTest extends End2EndTestCase
     }
 
     /**
+     * @return Webhook
+     *
      * @vcr e2e_webhook_create_update.json
      */
-    public function testCreateWebhook()
+    public function testCreateWebhook(): Webhook
     {
         $manager = $this->getReadWriteSpaceManager();
 
@@ -101,10 +104,14 @@ class WebhookTest extends End2EndTestCase
     }
 
     /**
+     * @param Webhook $webook
+     *
+     * @return Webhook
+     *
      * @depends testCreateWebhook
      * @vcr e2e_webhook_events_fired_and_logged.json
      */
-    public function testWebhookEventsFiredAndLogged(Webhook $webhook)
+    public function testWebhookEventsFiredAndLogged(Webhook $webhook): Webhook
     {
         $manager = $this->getReadWriteSpaceManager();
 
@@ -125,6 +132,7 @@ class WebhookTest extends End2EndTestCase
         $webhookId = $webhook->getSystemProperties()->getId();
 
         $health = $manager->getWebhookHealth($webhookId);
+        $this->assertEquals(new Link($health->getSystemProperties()->getId(), 'Webhook'), $health->asLink());
         $this->assertEquals(2, $health->getTotal());
         $this->assertEquals(0, $health->getHealthy());
         $this->assertEquals($webhookId, $health->getSystemProperties()->getId());
@@ -132,6 +140,7 @@ class WebhookTest extends End2EndTestCase
         $webhookCalls = $manager->getWebhookCalls($webhookId);
 
         $this->assertInstanceOf(WebhookCall::class, $webhookCalls[0]);
+        $this->assertEquals(new Link($webhookCalls[0]->getSystemProperties()->getId(), 'WebhookCallOverview'), $webhookCalls[0]->asLink());
         $this->assertEquals('create', $webhookCalls[0]->getEventType());
         $this->assertEquals('https://www.example.com/cf-xrLThVn5uBzHqB6tIbpV4aycgyisr5UAEQSafzkG', $webhookCalls[0]->getUrl());
 
@@ -151,6 +160,7 @@ class WebhookTest extends End2EndTestCase
         $this->assertNotNull($webhookCallId);
 
         $webhookCallDetails = $manager->getWebhookCallDetails($webhookId, $webhookCallId);
+        $this->assertEquals(new Link($webhookCallDetails->getSystemProperties()->getId(), 'WebhookCallDetails'), $webhookCallDetails->asLink());
         $requestPayload = json_decode($webhookCallDetails->getRequest()->getBody(), true);
         $this->assertEquals('Dwight Schrute', $requestPayload['fields']['name']['en-US']);
         $this->assertEquals('ContentManagement.Entry.create', $webhookCallDetails->getRequest()->getHeaders()['X-Contentful-Topic'][0]);
@@ -169,6 +179,8 @@ class WebhookTest extends End2EndTestCase
     }
 
     /**
+     * @param Webhook $webook
+     *
      * @depends testWebhookEventsFiredAndLogged
      * @vcr e2e_webhook_delete.json
      */

--- a/tests/Integration/Resource/ContentTypeSnapshotTest.php
+++ b/tests/Integration/Resource/ContentTypeSnapshotTest.php
@@ -10,17 +10,25 @@
 namespace Contentful\Tests\Integration;
 
 use Contentful\Management\ResourceBuilder;
+use Contentful\Management\Resource\ContentTypeSnapshot;
 use PHPUnit\Framework\TestCase;
 
 class ContentTypeSnapshotTest extends TestCase
 {
+    /**
+     * @expectedException \LogicException
+     */
+    public function testInvalidCreation()
+    {
+        new ContentTypeSnapshot();
+    }
+
     public function testJsonSerialize()
     {
-        $builder = new ResourceBuilder();
-
-        $data = [
+        $contentTypeSnapshot = (new ResourceBuilder())->buildObjectsFromRawData([
             'sys' => [
                 'type' => 'Snapshot',
+                'snapshotType' => 'publish',
                 'snapshotEntityType' => 'ContentType',
             ],
             'snapshot' => [
@@ -43,11 +51,10 @@ class ContentTypeSnapshotTest extends TestCase
                     'type' => 'ContentType',
                 ],
             ],
-        ];
+        ]);
 
-        $entrySnapshot = $builder->buildObjectsFromRawData($data);
-        $json = '{"sys":{"type":"Snapshot","snapshotEntityType":"ContentType"},"snapshot":{"name":"Versioned Content Type","displayField":"title","fields":[{"name":"Title","id":"title","type":"Symbol"},{"name":"Description","id":"description","type":"Text"}],"sys":{"id":"versionedContentType","type":"ContentType"}}}';
+        $json = '{"sys":{"type":"Snapshot","snapshotType":"publish","snapshotEntityType":"ContentType"},"snapshot":{"name":"Versioned Content Type","displayField":"title","fields":[{"name":"Title","id":"title","type":"Symbol"},{"name":"Description","id":"description","type":"Text"}],"sys":{"id":"versionedContentType","type":"ContentType"}}}';
 
-        $this->assertJsonStringEqualsJsonString($json, json_encode($entrySnapshot));
+        $this->assertJsonStringEqualsJsonString($json, json_encode($contentTypeSnapshot));
     }
 }

--- a/tests/Integration/Resource/EntrySnapshotTest.php
+++ b/tests/Integration/Resource/EntrySnapshotTest.php
@@ -10,17 +10,25 @@
 namespace Contentful\Tests\Unit\Resource;
 
 use Contentful\Management\ResourceBuilder;
+use Contentful\Management\Resource\EntrySnapshot;
 use PHPUnit\Framework\TestCase;
 
 class EntrySnapshotTest extends TestCase
 {
+    /**
+     * @expectedException \LogicException
+     */
+    public function testInvalidCreation()
+    {
+        new EntrySnapshot();
+    }
+
     public function testJsonSerialize()
     {
-        $builder = new ResourceBuilder();
-
-        $data = [
+        $entrySnapshot = (new ResourceBuilder())->buildObjectsFromRawData([
             'sys' => [
                 'type' => 'Snapshot',
+                'snapshotType' => 'publish',
                 'snapshotEntityType' => 'Entry',
             ],
             'snapshot' => [
@@ -36,10 +44,9 @@ class EntrySnapshotTest extends TestCase
                     'type' => 'Entry',
                 ],
             ],
-        ];
+        ]);
 
-        $entrySnapshot = $builder->buildObjectsFromRawData($data);
-        $json = '{"snapshot":{"sys":{"type":"Entry"},"fields":{"name":{"en-US":"Consuela Bananahammock"},"jobTitle":{"en-US":"Princess"}}},"sys":{"type":"Snapshot","snapshotEntityType":"Entry"}}';
+        $json = '{"snapshot":{"sys":{"type":"Entry"},"fields":{"name":{"en-US":"Consuela Bananahammock"},"jobTitle":{"en-US":"Princess"}}},"sys":{"type":"Snapshot","snapshotType":"publish","snapshotEntityType":"Entry"}}';
 
         $this->assertJsonStringEqualsJsonString($json, json_encode($entrySnapshot));
     }

--- a/tests/Integration/Resource/OrganizationTest.php
+++ b/tests/Integration/Resource/OrganizationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * This file is part of the contentful-management.php package.
+ *
+ * @copyright 2015-2017 Contentful GmbH
+ * @license   MIT
+ */
+
+namespace Contentful\Tests\Unit\Resource;
+
+use Contentful\Management\ResourceBuilder;
+use Contentful\Management\Resource\Organization;
+use PHPUnit\Framework\TestCase;
+
+class OrganizationTest extends TestCase
+{
+    /**
+     * @expectedException \LogicException
+     */
+    public function testInvalidCreation()
+    {
+        new Organization();
+    }
+
+    public function testJsonSerialize()
+    {
+        $organization = (new ResourceBuilder())->buildObjectsFromRawData([
+            'sys' => [
+                'type' => 'Organization',
+            ],
+            'name' => 'Test Org',
+        ]);
+
+        $json = '{"sys":{"type":"Organization"},"name":"Test Org"}';
+
+        $this->assertJsonStringEqualsJsonString($json, json_encode($organization));
+    }
+}

--- a/tests/Integration/Resource/PublishedContentTypeTest.php
+++ b/tests/Integration/Resource/PublishedContentTypeTest.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * This file is part of the contentful-management.php package.
+ *
+ * @copyright 2015-2017 Contentful GmbH
+ * @license   MIT
+ */
+
+namespace Contentful\Tests\Unit\Resource;
+
+use Contentful\Management\Resource\PublishedContentType;
+use PHPUnit\Framework\TestCase;
+
+class PublishedContentTypeTest extends TestCase
+{
+    /**
+     * @expectedException \LogicException
+     */
+    public function testInvalidCreation()
+    {
+        new PublishedContentType();
+    }
+}

--- a/tests/Integration/Resource/UserTest.php
+++ b/tests/Integration/Resource/UserTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * This file is part of the contentful-management.php package.
+ *
+ * @copyright 2015-2017 Contentful GmbH
+ * @license   MIT
+ */
+
+namespace Contentful\Tests\Unit\Resource;
+
+use Contentful\Management\ResourceBuilder;
+use Contentful\Management\Resource\User;
+use PHPUnit\Framework\TestCase;
+
+class UserTest extends TestCase
+{
+    /**
+     * @expectedException \LogicException
+     */
+    public function testInvalidCreation()
+    {
+        new User();
+    }
+
+    public function testJsonSerialize()
+    {
+        $user = (new ResourceBuilder())->buildObjectsFromRawData([
+            'sys' => [
+                'type' => 'User',
+            ],
+            'firstName' => 'Titus',
+            'lastName' => 'Andromedon',
+            'avatarUrl' => 'https://www.example.com/avatar.jpg',
+            'email' => 'pinotnoir@example.com',
+            'activated' => true,
+            'signInCount' => 10,
+            'confirmed' => true,
+        ]);
+
+        $json = '{"sys":{"type":"User"},"firstName":"Titus","lastName":"Andromedon","avatarUrl":"https://www.example.com/avatar.jpg","email":"pinotnoir@example.com","activated":true,"signInCount":10,"confirmed":true}';
+
+        $this->assertJsonStringEqualsJsonString($json, json_encode($user));
+    }
+}

--- a/tests/Integration/Resource/WebhookCallDetailsTest.php
+++ b/tests/Integration/Resource/WebhookCallDetailsTest.php
@@ -10,15 +10,22 @@
 namespace Contentful\Tests\Unit\Resource;
 
 use Contentful\Management\ResourceBuilder;
+use Contentful\Management\Resource\WebhookCallDetails;
 use PHPUnit\Framework\TestCase;
 
 class WebhookCallDetailsTest extends TestCase
 {
+    /**
+     * @expectedException \LogicException
+     */
+    public function testInvalidCreation()
+    {
+        new WebhookCallDetails();
+    }
+
     public function testJsonSerialize()
     {
-        $builder = new ResourceBuilder();
-
-        $data = [
+        $webhookCallDetails = (new ResourceBuilder())->buildObjectsFromRawData([
             'sys' => [
                 'type' => 'WebhookCallDetails',
             ],
@@ -46,9 +53,7 @@ class WebhookCallDetailsTest extends TestCase
             'url' => 'https://webhooks.example.com/endpoint',
             'requestAt' => '2016-03-01T08:43:22.024Z',
             'responseAt' => '2016-03-01T08:43:22.330Z',
-        ];
-
-        $webhookCallDetails = $builder->buildObjectsFromRawData($data);
+        ]);
 
         $json = '{"sys":{"type":"WebhookCallDetails"},"request":{"url":"https:\/\/webhooks.example.com\/endpoint","method":"POST","headers":{"X-Contentful-Topic":"ContentManagement.Entry.publish","Content-Type":"application\/vnd.contentful.management.v1+json"},"body":"{}"},"response":{"url":"https:\/\/webhooks.example.com\/endpoint","headers":{"Content-Type":"text\/html; charset=utf-8","Content-Length":"2"},"body":"ok","statusCode":200},"statusCode":200,"errors":[],"eventType":"publish","url":"https:\/\/webhooks.example.com\/endpoint","requestAt":"2016-03-01T08:43:22.024Z","responseAt":"2016-03-01T08:43:22.330Z"}';
 

--- a/tests/Integration/Resource/WebhookCallTest.php
+++ b/tests/Integration/Resource/WebhookCallTest.php
@@ -10,15 +10,22 @@
 namespace Contentful\Tests\Unit\Resource;
 
 use Contentful\Management\ResourceBuilder;
+use Contentful\Management\Resource\WebhookCall;
 use PHPUnit\Framework\TestCase;
 
 class WebhookCallTest extends TestCase
 {
+    /**
+     * @expectedException \LogicException
+     */
+    public function testInvalidCreation()
+    {
+        new WebhookCall();
+    }
+
     public function testJsonSerialize()
     {
-        $builder = new ResourceBuilder();
-
-        $data = [
+        $webhookCall = (new ResourceBuilder())->buildObjectsFromRawData([
             'sys' => [
                 'type' => 'WebhookCallOverview',
             ],
@@ -28,12 +35,10 @@ class WebhookCallTest extends TestCase
             'url' => 'https://webhooks.example.com/endpoint',
             'requestAt' => '2016-03-01T08:43:22.024Z',
             'responseAt' => '2016-03-01T08:43:22.330Z',
-        ];
-
-        $webhookCallDetails = $builder->buildObjectsFromRawData($data);
+        ]);
 
         $json = '{"sys":{"type":"WebhookCallOverview"},"statusCode":200,"errors":[],"eventType":"publish","url":"https:\/\/webhooks.example.com\/endpoint","requestAt":"2016-03-01T08:43:22.024Z","responseAt":"2016-03-01T08:43:22.330Z"}';
 
-        $this->assertJsonStringEqualsJsonString($json, json_encode($webhookCallDetails));
+        $this->assertJsonStringEqualsJsonString($json, json_encode($webhookCall));
     }
 }

--- a/tests/Integration/Resource/WebhookHealthTest.php
+++ b/tests/Integration/Resource/WebhookHealthTest.php
@@ -9,22 +9,34 @@
 
 namespace Contentful\Tests\Unit\Resource;
 
-use Contentful\Management\Resource\WebhookHealth;
 use Contentful\Management\ResourceBuilder;
+use Contentful\Management\Resource\WebhookHealth;
 use PHPUnit\Framework\TestCase;
 
 class WebhookHealthTest extends TestCase
 {
+    /**
+     * @expectedException \LogicException
+     */
+    public function testInvalidCreation()
+    {
+        new WebhookHealth();
+    }
+
     public function testJsonSerialize()
     {
-        $webhookHealth = new WebhookHealth();
-        $json = '{"sys":{"type":"Webhook"},"calls":{"total":0,"healthy":0}}';
-        $this->assertJsonStringEqualsJsonString($json, json_encode($webhookHealth));
+        $webhookHealth = (new ResourceBuilder())->buildObjectsFromRawData([
+            'sys' => [
+                'type' => 'Webhook',
+            ],
+            'calls' => [
+                'total' => 233,
+                'healthy' => 102,
+                ],
+            ]
+        );
 
         $json = '{"sys":{"type":"Webhook"},"calls":{"total":233,"healthy":102}}';
-
-        $webhookHealth = (new ResourceBuilder())
-            ->buildObjectsFromRawData(['sys' => ['type' => 'Webhook'], 'calls' => ['total' => 233, 'healthy' => 102]]);
 
         $this->assertJsonStringEqualsJsonString($json, json_encode($webhookHealth));
     }

--- a/tests/Unit/Resource/WebhookTest.php
+++ b/tests/Unit/Resource/WebhookTest.php
@@ -20,6 +20,8 @@ class WebhookTest extends TestCase
 
         $this->assertEquals('Test Webhook', $webhook->getName());
         $this->assertEquals('https://www.example.com/webhook', $webhook->getUrl());
+        $webhook->setName('Another name');
+        $this->assertEquals('Another name', $webhook->getName());
 
         $sys = $webhook->getSystemProperties();
         $this->assertEquals('WebhookDefinition', $sys->getType());


### PR DESCRIPTION
- Introduces a `BaseResource` class with shared functionality.
- Removes useless declarations of `SpaceScopedResourceInterface` when classes are already implementing a `*able` interface which extends it.
- Blocks the constructors of some resource classes which should never be manually instantiated, as they can only represent results of API calls (things like `WebhookCallDetails`, `Organization`, etc).

Test have been slightly refactored: some tests were redefined as "integration tests" rather than "unit tests": in order to test JSON serialization of classes that can't be instantiated, the `ResourceBuilder` is used. This makes the test not atomic, hence the redefinition.

Closes #49 
Closes #42 