### PR TITLE
Add support for rich text fields and custom validation messages

### DIFF
--- a/src/Mapper/BaseMapper.php
+++ b/src/Mapper/BaseMapper.php
@@ -43,18 +43,24 @@ abstract class BaseMapper implements MapperInterface
 
     protected function mapValidation(array $data): ?ValidationInterface
     {
+        $message = null;
+        if (isset($data['message'])) {
+            $message = $data['message'];
+            unset($data['message']);
+        }
+
         if (empty(array_values($data)[0])) {
             return null;
         }
 
-        $fqcn = '\\Contentful\\Management\\Mapper\\ContentType\\Validation\\'.\ucfirst(\array_keys($data)[0]).'Validation';
+        $fqcn = '\\Contentful\\Management\\Mapper\\ContentType\\Validation\\'.\ucfirst(key($data)).'Validation';
 
         /** @var ValidationInterface $validation */
         $validation = $this->builder->getMapper($fqcn)
             ->map(null, $data);
 
-        if ($validation instanceof AbstractCustomMessageValidation && isset($data['message'])) {
-            $validation->setMessage($data['message']);
+        if ($validation instanceof AbstractCustomMessageValidation && $message) {
+            $validation->setMessage($message);
         }
 
         return $validation;

--- a/src/Mapper/BaseMapper.php
+++ b/src/Mapper/BaseMapper.php
@@ -13,6 +13,8 @@ namespace Contentful\Management\Mapper;
 
 use Contentful\Core\ResourceBuilder\MapperInterface;
 use Contentful\Core\ResourceBuilder\ObjectHydrator;
+use Contentful\Management\Resource\ContentType\Validation\AbstractCustomMessageValidation;
+use Contentful\Management\Resource\ContentType\Validation\ValidationInterface;
 use Contentful\Management\ResourceBuilder;
 
 /**
@@ -37,5 +39,24 @@ abstract class BaseMapper implements MapperInterface
     {
         $this->builder = $builder;
         $this->hydrator = new ObjectHydrator();
+    }
+
+    protected function mapValidation(array $data): ?ValidationInterface
+    {
+        if (empty(array_values($data)[0])) {
+            return null;
+        }
+
+        $fqcn = '\\Contentful\\Management\\Mapper\\ContentType\\Validation\\'.\ucfirst(\array_keys($data)[0]).'Validation';
+
+        /** @var ValidationInterface $validation */
+        $validation = $this->builder->getMapper($fqcn)
+            ->map(null, $data);
+
+        if ($validation instanceof AbstractCustomMessageValidation && isset($data['message'])) {
+            $validation->setMessage($data['message']);
+        }
+
+        return $validation;
     }
 }

--- a/src/Mapper/ContentType/Field/BaseField.php
+++ b/src/Mapper/ContentType/Field/BaseField.php
@@ -22,6 +22,7 @@ use Contentful\Management\Resource\ContentType\Field\ObjectField;
 use Contentful\Management\Resource\ContentType\Field\RichTextField;
 use Contentful\Management\Resource\ContentType\Field\SymbolField;
 use Contentful\Management\Resource\ContentType\Field\TextField;
+use Contentful\Management\Resource\ContentType\Validation\AbstractCustomMessageValidation;
 use Contentful\Management\Resource\ContentType\Validation\ValidationInterface;
 
 /**
@@ -73,8 +74,11 @@ abstract class BaseField extends BaseMapper
 
         /** @var ValidationInterface $validation */
         $validation = $this->builder->getMapper($fqcn)
-            ->map(null, $data)
-        ;
+            ->map(null, $data);
+
+        if ($validation instanceof AbstractCustomMessageValidation && isset($data['message'])) {
+            $validation->setMessage($data['message']);
+        }
 
         return $validation;
     }

--- a/src/Mapper/ContentType/Field/BaseField.php
+++ b/src/Mapper/ContentType/Field/BaseField.php
@@ -22,8 +22,6 @@ use Contentful\Management\Resource\ContentType\Field\ObjectField;
 use Contentful\Management\Resource\ContentType\Field\RichTextField;
 use Contentful\Management\Resource\ContentType\Field\SymbolField;
 use Contentful\Management\Resource\ContentType\Field\TextField;
-use Contentful\Management\Resource\ContentType\Validation\AbstractCustomMessageValidation;
-use Contentful\Management\Resource\ContentType\Validation\ValidationInterface;
 
 /**
  * BaseField class.
@@ -62,24 +60,5 @@ abstract class BaseField extends BaseMapper
         ]);
 
         return $field;
-    }
-
-    protected function mapValidation(array $data): ?ValidationInterface
-    {
-        if (empty(array_values($data)[0])) {
-            return null;
-        }
-
-        $fqcn = '\\Contentful\\Management\\Mapper\\ContentType\\Validation\\'.\ucfirst(\array_keys($data)[0]).'Validation';
-
-        /** @var ValidationInterface $validation */
-        $validation = $this->builder->getMapper($fqcn)
-            ->map(null, $data);
-
-        if ($validation instanceof AbstractCustomMessageValidation && isset($data['message'])) {
-            $validation->setMessage($data['message']);
-        }
-
-        return $validation;
     }
 }

--- a/src/Mapper/ContentType/Field/BaseField.php
+++ b/src/Mapper/ContentType/Field/BaseField.php
@@ -56,15 +56,19 @@ abstract class BaseField extends BaseMapper
             'disabled' => $data['disabled'] ?? null,
             'omitted' => $data['omitted'] ?? null,
             'validations' => isset($data['validations'])
-                ? \array_map([$this, 'mapValidation'], $data['validations'])
+                ? \array_filter(\array_map([$this, 'mapValidation'], $data['validations']))
                 : [],
         ]);
 
         return $field;
     }
 
-    protected function mapValidation(array $data): ValidationInterface
+    protected function mapValidation(array $data): ?ValidationInterface
     {
+        if (empty(array_values($data)[0])) {
+            return null;
+        }
+
         $fqcn = '\\Contentful\\Management\\Mapper\\ContentType\\Validation\\'.\ucfirst(\array_keys($data)[0]).'Validation';
 
         /** @var ValidationInterface $validation */

--- a/src/Mapper/ContentType/Validation/EnabledMarksValidation.php
+++ b/src/Mapper/ContentType/Validation/EnabledMarksValidation.php
@@ -24,6 +24,6 @@ class EnabledMarksValidation extends BaseMapper
      */
     public function map($resource, array $data): ResourceClass
     {
-        return new ResourceClass();
+        return new ResourceClass($data['enabledMarks']);
     }
 }

--- a/src/Mapper/ContentType/Validation/EnabledNodeTypesValidation.php
+++ b/src/Mapper/ContentType/Validation/EnabledNodeTypesValidation.php
@@ -24,6 +24,6 @@ class EnabledNodeTypesValidation extends BaseMapper
      */
     public function map($resource, array $data): ResourceClass
     {
-        return new ResourceClass();
+        return new ResourceClass($data['enabledNodeTypes']);
     }
 }

--- a/src/Mapper/ContentType/Validation/NodesValidation.php
+++ b/src/Mapper/ContentType/Validation/NodesValidation.php
@@ -24,6 +24,22 @@ class NodesValidation extends BaseMapper
      */
     public function map($resource, array $data): ResourceClass
     {
-        return new ResourceClass();
+        return new ResourceClass(
+            isset($data['nodes']['asset-hyperlink']) ?
+                \array_map([$this, 'mapValidation'], $data['nodes']['asset-hyperlink']) :
+                [],
+            isset($data['nodes']['embedded-asset-block']) ?
+                \array_map([$this, 'mapValidation'], $data['nodes']['embedded-asset-block']) :
+                [],
+            isset($data['nodes']['embedded-entry-block']) ?
+                \array_map([$this, 'mapValidation'], $data['nodes']['embedded-entry-block']) :
+                [],
+            isset($data['nodes']['embedded-entry-inline']) ?
+                \array_map([$this, 'mapValidation'], $data['nodes']['embedded-entry-inline']) :
+                [],
+            isset($data['nodes']['entry-hyperlink']) ?
+                \array_map([$this, 'mapValidation'], $data['nodes']['entry-hyperlink']) :
+                []
+        );
     }
 }

--- a/src/Resource/ContentType/Validation/AbstractCustomMessageValidation.php
+++ b/src/Resource/ContentType/Validation/AbstractCustomMessageValidation.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace Contentful\Management\Resource\ContentType\Validation;
+
+abstract class AbstractCustomMessageValidation
+{
+    /**
+     * @var string|null
+     */
+    private $message;
+
+    public function setMessage(string $message): self
+    {
+        $this->message = $message;
+
+        return $this;
+    }
+
+    public function getMessage(): ?string
+    {
+        return $this->message;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->message ? ['message' => $this->message] : [];
+    }
+}

--- a/src/Resource/ContentType/Validation/AssetFileSizeValidation.php
+++ b/src/Resource/ContentType/Validation/AssetFileSizeValidation.php
@@ -19,7 +19,7 @@ namespace Contentful\Management\Resource\ContentType\Validation;
  * Applicable to:
  * - Link (to assets)
  */
-class AssetFileSizeValidation implements ValidationInterface
+class AssetFileSizeValidation extends AbstractCustomMessageValidation implements ValidationInterface
 {
     /**
      * @var int|null
@@ -100,8 +100,9 @@ class AssetFileSizeValidation implements ValidationInterface
             $data['max'] = $this->max;
         }
 
-        return [
+        return array_merge(
+            parent::jsonSerialize(), [
             'assetFileSize' => $data,
-        ];
+        ]);
     }
 }

--- a/src/Resource/ContentType/Validation/AssetImageDimensionsValidation.php
+++ b/src/Resource/ContentType/Validation/AssetImageDimensionsValidation.php
@@ -19,7 +19,7 @@ namespace Contentful\Management\Resource\ContentType\Validation;
  * Applicable to:
  * - Link (to image assets)
  */
-class AssetImageDimensionsValidation implements ValidationInterface
+class AssetImageDimensionsValidation extends AbstractCustomMessageValidation implements ValidationInterface
 {
     /**
      * @var int|null
@@ -161,8 +161,11 @@ class AssetImageDimensionsValidation implements ValidationInterface
             $data['height'] = $heightData;
         }
 
-        return [
-            'assetImageDimensions' => $data,
-        ];
+        return array_merge(
+            parent::jsonSerialize(),
+            [
+                'assetImageDimensions' => $data,
+            ]
+        );
     }
 }

--- a/src/Resource/ContentType/Validation/DateRangeValidation.php
+++ b/src/Resource/ContentType/Validation/DateRangeValidation.php
@@ -19,7 +19,7 @@ namespace Contentful\Management\Resource\ContentType\Validation;
  * Applicable to:
  * - Date
  */
-class DateRangeValidation implements ValidationInterface
+class DateRangeValidation extends AbstractCustomMessageValidation implements ValidationInterface
 {
     /**
      * @var string|null
@@ -97,8 +97,11 @@ class DateRangeValidation implements ValidationInterface
             $data['max'] = $this->max;
         }
 
-        return [
-            'dateRange' => $data,
-        ];
+        return array_merge(
+            parent::jsonSerialize(),
+            [
+                'dateRange' => $data,
+            ]
+        );
     }
 }

--- a/src/Resource/ContentType/Validation/EnabledMarksValidation.php
+++ b/src/Resource/ContentType/Validation/EnabledMarksValidation.php
@@ -16,12 +16,34 @@ namespace Contentful\Management\Resource\ContentType\Validation;
  */
 class EnabledMarksValidation implements ValidationInterface
 {
+    private const VALID_FIELD_TYPES = ['RichText'];
+
+    /**
+     * @var array
+     */
+    private $enabledMarks;
+
+    public function __construct(array $enabledMarks)
+    {
+        $this->enabledMarks = $enabledMarks;
+    }
+
     /**
      * {@inheritdoc}
      */
     public static function getValidFieldTypes(): array
     {
-        return [];
+        return self::VALID_FIELD_TYPES;
+    }
+
+    public function getEnabledMarks(): array
+    {
+        return $this->enabledMarks;
+    }
+
+    public function setEnabledMarks(array $enabledMarks)
+    {
+        $this->enabledMarks = $enabledMarks;
     }
 
     /**
@@ -29,6 +51,6 @@ class EnabledMarksValidation implements ValidationInterface
      */
     public function jsonSerialize()
     {
-        return [];
+        return ['enabledMarks' => $this->enabledMarks];
     }
 }

--- a/src/Resource/ContentType/Validation/EnabledNodeTypesValidation.php
+++ b/src/Resource/ContentType/Validation/EnabledNodeTypesValidation.php
@@ -16,12 +16,34 @@ namespace Contentful\Management\Resource\ContentType\Validation;
  */
 class EnabledNodeTypesValidation implements ValidationInterface
 {
+    private const VALID_FIELD_TYPES = ['RichText'];
+
+    /**
+     * @var array
+     */
+    private $enabledNodeTypes;
+
+    public function __construct(array $enabledNodeTypes)
+    {
+        $this->enabledNodeTypes = $enabledNodeTypes;
+    }
+
     /**
      * {@inheritdoc}
      */
     public static function getValidFieldTypes(): array
     {
-        return [];
+        return self::VALID_FIELD_TYPES;
+    }
+
+    public function getEnabledNodeTypes(): array
+    {
+        return $this->enabledNodeTypes;
+    }
+
+    public function setEnabledNodeTypes(array $enabledNodeTypes)
+    {
+        $this->enabledNodeTypes = $enabledNodeTypes;
     }
 
     /**
@@ -29,6 +51,6 @@ class EnabledNodeTypesValidation implements ValidationInterface
      */
     public function jsonSerialize()
     {
-        return [];
+        return ['enabledNodeTypes' => $this->enabledNodeTypes];
     }
 }

--- a/src/Resource/ContentType/Validation/InValidation.php
+++ b/src/Resource/ContentType/Validation/InValidation.php
@@ -22,7 +22,7 @@ namespace Contentful\Management\Resource\ContentType\Validation;
  * - Integer
  * - Number
  */
-class InValidation implements ValidationInterface
+class InValidation extends AbstractCustomMessageValidation implements ValidationInterface
 {
     /**
      * @var string[]
@@ -72,8 +72,11 @@ class InValidation implements ValidationInterface
      */
     public function jsonSerialize(): array
     {
-        return [
-            'in' => $this->values,
-        ];
+        return array_merge(
+            parent::jsonSerialize(),
+            [
+                'in' => $this->values,
+            ]
+        );
     }
 }

--- a/src/Resource/ContentType/Validation/LinkContentTypeValidation.php
+++ b/src/Resource/ContentType/Validation/LinkContentTypeValidation.php
@@ -20,7 +20,7 @@ namespace Contentful\Management\Resource\ContentType\Validation;
  * Applicable to:
  * - Link (to entries)
  */
-class LinkContentTypeValidation implements ValidationInterface
+class LinkContentTypeValidation extends AbstractCustomMessageValidation implements ValidationInterface
 {
     /**
      * @var string[]
@@ -70,8 +70,11 @@ class LinkContentTypeValidation implements ValidationInterface
      */
     public function jsonSerialize(): array
     {
-        return [
-            'linkContentType' => $this->contentTypes,
-        ];
+        return array_merge(
+            parent::jsonSerialize(),
+            [
+                'linkContentType' => $this->contentTypes,
+            ]
+        );
     }
 }

--- a/src/Resource/ContentType/Validation/LinkContentTypeValidation.php
+++ b/src/Resource/ContentType/Validation/LinkContentTypeValidation.php
@@ -11,6 +11,10 @@ declare(strict_types=1);
 
 namespace Contentful\Management\Resource\ContentType\Validation;
 
+use Contentful\Management\Resource\ContentType\Validation\Nodes\EmbeddedEntryBlockValidationInterface;
+use Contentful\Management\Resource\ContentType\Validation\Nodes\EmbeddedEntryInlineValidationInterface;
+use Contentful\Management\Resource\ContentType\Validation\Nodes\EntryHyperlinkValidationInterface;
+
 /**
  * LinkContentTypeValidation class.
  *
@@ -20,7 +24,10 @@ namespace Contentful\Management\Resource\ContentType\Validation;
  * Applicable to:
  * - Link (to entries)
  */
-class LinkContentTypeValidation extends AbstractCustomMessageValidation implements ValidationInterface
+class LinkContentTypeValidation extends AbstractCustomMessageValidation implements ValidationInterface,
+    EntryHyperlinkValidationInterface,
+    EmbeddedEntryBlockValidationInterface,
+    EmbeddedEntryInlineValidationInterface
 {
     /**
      * @var string[]

--- a/src/Resource/ContentType/Validation/LinkMimetypeGroupValidation.php
+++ b/src/Resource/ContentType/Validation/LinkMimetypeGroupValidation.php
@@ -20,7 +20,7 @@ namespace Contentful\Management\Resource\ContentType\Validation;
  * Applicable to:
  * - Link (to assets)
  */
-class LinkMimetypeGroupValidation implements ValidationInterface
+class LinkMimetypeGroupValidation extends AbstractCustomMessageValidation implements ValidationInterface
 {
     /**
      * @var string[]
@@ -70,8 +70,11 @@ class LinkMimetypeGroupValidation implements ValidationInterface
      */
     public function jsonSerialize(): array
     {
-        return [
-            'linkMimetypeGroup' => $this->mimeTypeGroups,
-        ];
+        return array_merge(
+            parent::jsonSerialize(),
+            [
+                'linkMimetypeGroup' => $this->mimeTypeGroups,
+            ]
+        );
     }
 }

--- a/src/Resource/ContentType/Validation/Nodes/AssetHyperlinkValidationInterface.php
+++ b/src/Resource/ContentType/Validation/Nodes/AssetHyperlinkValidationInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Contentful\Management\Resource\ContentType\Validation\Nodes;
+
+use Contentful\Management\Resource\ContentType\Validation\ValidationInterface;
+
+interface AssetHyperlinkValidationInterface extends ValidationInterface
+{
+
+}

--- a/src/Resource/ContentType/Validation/Nodes/EmbeddedAssetBlockValidationInterface.php
+++ b/src/Resource/ContentType/Validation/Nodes/EmbeddedAssetBlockValidationInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Contentful\Management\Resource\ContentType\Validation\Nodes;
+
+use Contentful\Management\Resource\ContentType\Validation\ValidationInterface;
+
+interface EmbeddedAssetBlockValidationInterface extends ValidationInterface
+{
+
+}

--- a/src/Resource/ContentType/Validation/Nodes/EmbeddedEntryBlockValidationInterface.php
+++ b/src/Resource/ContentType/Validation/Nodes/EmbeddedEntryBlockValidationInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Contentful\Management\Resource\ContentType\Validation\Nodes;
+
+use Contentful\Management\Resource\ContentType\Validation\ValidationInterface;
+
+interface EmbeddedEntryBlockValidationInterface extends ValidationInterface
+{
+
+}

--- a/src/Resource/ContentType/Validation/Nodes/EmbeddedEntryInlineValidationInterface.php
+++ b/src/Resource/ContentType/Validation/Nodes/EmbeddedEntryInlineValidationInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Contentful\Management\Resource\ContentType\Validation\Nodes;
+
+use Contentful\Management\Resource\ContentType\Validation\ValidationInterface;
+
+interface EmbeddedEntryInlineValidationInterface extends ValidationInterface
+{
+
+}

--- a/src/Resource/ContentType/Validation/Nodes/EntryHyperlinkValidationInterface.php
+++ b/src/Resource/ContentType/Validation/Nodes/EntryHyperlinkValidationInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Contentful\Management\Resource\ContentType\Validation\Nodes;
+
+use Contentful\Management\Resource\ContentType\Validation\ValidationInterface;
+
+interface EntryHyperlinkValidationInterface extends ValidationInterface
+{
+
+}

--- a/src/Resource/ContentType/Validation/NodesValidation.php
+++ b/src/Resource/ContentType/Validation/NodesValidation.php
@@ -11,24 +11,176 @@ declare(strict_types=1);
 
 namespace Contentful\Management\Resource\ContentType\Validation;
 
-/**
- * NodesValidation class stub.
- */
+use Contentful\Management\Resource\ContentType\Validation\Nodes\AssetHyperlinkValidationInterface;
+use Contentful\Management\Resource\ContentType\Validation\Nodes\EmbeddedAssetBlockValidationInterface;
+use Contentful\Management\Resource\ContentType\Validation\Nodes\EmbeddedEntryBlockValidationInterface;
+use Contentful\Management\Resource\ContentType\Validation\Nodes\EmbeddedEntryInlineValidationInterface;
+use Contentful\Management\Resource\ContentType\Validation\Nodes\EntryHyperlinkValidationInterface;
+
 class NodesValidation implements ValidationInterface
 {
+    private const VALID_FIELD_TYPES = ['RichText'];
+
     /**
-     * {@inheritdoc}
+     * @var array
      */
-    public static function getValidFieldTypes(): array
-    {
-        return [];
+    private $assetHyperlinkValidations;
+
+    /**
+     * @var array
+     */
+    private $embeddedAssetBlockValidations;
+
+    /**
+     * @var array
+     */
+    private $embeddedEntryBlockValidations;
+
+    /**
+     * @var array
+     */
+    private $embeddedEntryInlineValidations;
+
+    /**
+     * @var array
+     */
+    private $entryHyperlinkValidations;
+
+    public function __construct(
+        array $assetHyperlinkValidations = [],
+        array $embeddedAssetBlockValidations = [],
+        array $embeddedEntryBlockValidations = [],
+        array $embeddedEntryInlineValidations = [],
+        array $entryHyperlinkValidations = []
+    ) {
+        $this->assetHyperlinkValidations = $assetHyperlinkValidations;
+        $this->embeddedAssetBlockValidations = $embeddedAssetBlockValidations;
+        $this->embeddedEntryBlockValidations = $embeddedEntryBlockValidations;
+        $this->embeddedEntryInlineValidations = $embeddedEntryInlineValidations;
+        $this->entryHyperlinkValidations = $entryHyperlinkValidations;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function jsonSerialize()
+    public static function getValidFieldTypes(): array
     {
-        return [];
+        return self::VALID_FIELD_TYPES;
+    }
+
+    public function getAssetHyperlinkValidations(): array
+    {
+        return $this->assetHyperlinkValidations;
+    }
+
+    public function addAssetHyperlinkValidation(AssetHyperlinkValidationInterface $assetHyperlinkValidation): self
+    {
+        $this->assetHyperlinkValidations[] = $assetHyperlinkValidation;
+
+        return $this;
+    }
+
+    public function resetAssetHyperlinkValidations(): self
+    {
+        $this->assetHyperlinkValidations = [];
+
+        return $this;
+    }
+
+    public function getEmbeddedAssetBlockValidations(): array
+    {
+        return $this->embeddedAssetBlockValidations;
+    }
+
+    public function addEmbeddedAssetBlockValidation(
+        EmbeddedAssetBlockValidationInterface $embeddedAssetBlockValidation
+    ): self {
+        $this->embeddedAssetBlockValidations[] = $embeddedAssetBlockValidation;
+
+        return $this;
+    }
+
+    public function resetEmbeddedAssetBlockValidations(): self
+    {
+        $this->embeddedAssetBlockValidations = [];
+
+        return $this;
+    }
+
+    public function getEmbeddedEntryBlockValidations(): array
+    {
+        return $this->embeddedEntryBlockValidations;
+    }
+
+    public function addEmbeddedEntryBlockValidation(
+        EmbeddedEntryBlockValidationInterface $embeddedEntryBlockValidation
+    ): self {
+        $this->embeddedEntryBlockValidations[] = $embeddedEntryBlockValidation;
+
+        return $this;
+    }
+
+    public function resetEmbeddedEntryBlockValidations(): self
+    {
+        $this->embeddedEntryBlockValidations = [];
+
+        return $this;
+    }
+
+    public function getEmbeddedEntryInlineValidations(): array
+    {
+        return $this->embeddedEntryInlineValidations;
+    }
+
+    public function addEmbeddedEntryInlineValidation(
+        EmbeddedEntryInlineValidationInterface $embeddedEntryInlineValidation
+    ): self {
+        $this->embeddedEntryInlineValidations[] = $embeddedEntryInlineValidation;
+
+        return $this;
+    }
+
+    public function resetEmbeddedEntryInlineValidations(): self
+    {
+        $this->embeddedEntryInlineValidations = [];
+
+        return $this;
+    }
+
+    public function getEntryHyperlinkValidations(): array
+    {
+        return $this->entryHyperlinkValidations;
+    }
+
+    public function addEntryHyperlinkValidation(EntryHyperlinkValidationInterface $entryHyperlinkValidation): self
+    {
+        $this->entryHyperlinkValidations[] = $entryHyperlinkValidation;
+
+        return $this;
+    }
+
+    public function resetEntryHyperlinkValidations(): self
+    {
+        $this->entryHyperlinkValidations = [];
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function jsonSerialize(): array
+    {
+        return [
+            'nodes' => \array_filter(
+                [
+                    'asset-hyperlink' => $this->assetHyperlinkValidations,
+                    'embedded-asset-block' => $this->embeddedAssetBlockValidations,
+                    'embedded-entry-block' => $this->embeddedEntryBlockValidations,
+                    'embedded-entry-inline' => $this->embeddedEntryInlineValidations,
+                    'entry-hyperlink' => $this->entryHyperlinkValidations,
+                ]
+            ),
+        ];
     }
 }

--- a/src/Resource/ContentType/Validation/RangeValidation.php
+++ b/src/Resource/ContentType/Validation/RangeValidation.php
@@ -20,7 +20,7 @@ namespace Contentful\Management\Resource\ContentType\Validation;
  * - Integer
  * - Number
  */
-class RangeValidation implements ValidationInterface
+class RangeValidation extends AbstractCustomMessageValidation implements ValidationInterface
 {
     /**
      * @var int|null
@@ -98,8 +98,11 @@ class RangeValidation implements ValidationInterface
             $data['max'] = $this->max;
         }
 
-        return [
-            'range' => $data,
-        ];
+        return array_merge(
+            parent::jsonSerialize(),
+            [
+                'range' => $data,
+            ]
+        );
     }
 }

--- a/src/Resource/ContentType/Validation/RegexpValidation.php
+++ b/src/Resource/ContentType/Validation/RegexpValidation.php
@@ -20,7 +20,7 @@ namespace Contentful\Management\Resource\ContentType\Validation;
  * - Symbol
  * - Text
  */
-class RegexpValidation implements ValidationInterface
+class RegexpValidation extends AbstractCustomMessageValidation implements ValidationInterface
 {
     /**
      * @var string|null
@@ -88,8 +88,11 @@ class RegexpValidation implements ValidationInterface
             $data['flags'] = $this->flags;
         }
 
-        return [
-            'regexp' => $data,
-        ];
+        return array_merge(
+            parent::jsonSerialize(),
+            [
+                'regexp' => $data,
+            ]
+        );
     }
 }

--- a/src/Resource/ContentType/Validation/SizeValidation.php
+++ b/src/Resource/ContentType/Validation/SizeValidation.php
@@ -22,7 +22,7 @@ namespace Contentful\Management\Resource\ContentType\Validation;
  * - Symbol
  * - Text
  */
-class SizeValidation implements ValidationInterface
+class SizeValidation extends AbstractCustomMessageValidation implements ValidationInterface
 {
     /**
      * @var int|null
@@ -103,8 +103,11 @@ class SizeValidation implements ValidationInterface
             $data['max'] = $this->max;
         }
 
-        return [
-            'size' => $data,
-        ];
+        return array_merge(
+            parent::jsonSerialize(),
+            [
+                'size' => $data,
+            ]
+        );
     }
 }

--- a/src/Resource/ContentType/Validation/SizeValidation.php
+++ b/src/Resource/ContentType/Validation/SizeValidation.php
@@ -11,6 +11,12 @@ declare(strict_types=1);
 
 namespace Contentful\Management\Resource\ContentType\Validation;
 
+use Contentful\Management\Resource\ContentType\Validation\Nodes\AssetHyperlinkValidationInterface;
+use Contentful\Management\Resource\ContentType\Validation\Nodes\EmbeddedAssetBlockValidationInterface;
+use Contentful\Management\Resource\ContentType\Validation\Nodes\EmbeddedEntryBlockValidationInterface;
+use Contentful\Management\Resource\ContentType\Validation\Nodes\EmbeddedEntryInlineValidationInterface;
+use Contentful\Management\Resource\ContentType\Validation\Nodes\EntryHyperlinkValidationInterface;
+
 /**
  * SizeValidation class.
  *
@@ -22,7 +28,12 @@ namespace Contentful\Management\Resource\ContentType\Validation;
  * - Symbol
  * - Text
  */
-class SizeValidation extends AbstractCustomMessageValidation implements ValidationInterface
+class SizeValidation extends AbstractCustomMessageValidation implements ValidationInterface,
+    AssetHyperlinkValidationInterface,
+    EmbeddedAssetBlockValidationInterface,
+    EmbeddedEntryBlockValidationInterface,
+    EmbeddedEntryInlineValidationInterface,
+    EntryHyperlinkValidationInterface
 {
     /**
      * @var int|null

--- a/tests/Fixtures/Unit/Resource/ContentType/Validation/enabled_marks_validation.json
+++ b/tests/Fixtures/Unit/Resource/ContentType/Validation/enabled_marks_validation.json
@@ -1,0 +1,6 @@
+{
+    "enabledMarks": [
+        "bold",
+        "code"
+    ]
+}

--- a/tests/Fixtures/Unit/Resource/ContentType/Validation/enabled_node_types_validation.json
+++ b/tests/Fixtures/Unit/Resource/ContentType/Validation/enabled_node_types_validation.json
@@ -1,0 +1,7 @@
+{
+    "enabledNodeTypes": [
+        "heading-1",
+        "heading-2",
+        "ordered-list"
+    ]
+}

--- a/tests/Fixtures/Unit/Resource/ContentType/Validation/nodes_validation.json
+++ b/tests/Fixtures/Unit/Resource/ContentType/Validation/nodes_validation.json
@@ -1,0 +1,55 @@
+{
+    "nodes": {
+        "asset-hyperlink": [
+            {
+                "size": {
+                    "min": 1
+                }
+            }
+        ],
+        "embedded-asset-block": [
+            {
+                "size": {
+                    "max": 1
+                }
+            }
+        ],
+        "embedded-entry-block": [
+            {
+                "linkContentType": [
+                    "test"
+                ]
+            },
+            {
+                "size": {
+                    "min": 1,
+                    "max": 2
+                }
+            }
+        ],
+        "embedded-entry-inline": [
+            {
+                "linkContentType": [
+                    "test"
+                ]
+            },
+            {
+                "size": {
+                    "min": 1
+                }
+            }
+        ],
+        "entry-hyperlink": [
+            {
+                "linkContentType": [
+                    "test"
+                ]
+            },
+            {
+                "size": {
+                    "min": 1
+                }
+            }
+        ]
+    }
+}

--- a/tests/Unit/Resource/ContentType/Validation/EnabledMarksValidationTest.php
+++ b/tests/Unit/Resource/ContentType/Validation/EnabledMarksValidationTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * This file is part of the contentful/contentful-management package.
+ *
+ * @copyright 2015-2020 Contentful GmbH
+ * @license   MIT
+ */
+
+declare(strict_types=1);
+
+namespace Contentful\Tests\Management\Unit\Resource\ContentType\Validation;
+
+use Contentful\Management\Resource\ContentType\Validation\EnabledMarksValidation;
+use Contentful\Tests\Management\BaseTestCase;
+
+class EnabledMarksValidationTest extends BaseTestCase
+{
+    public function testJsonSerialize()
+    {
+        $validation = new EnabledMarksValidation(['bold', 'code']);
+
+        $this->assertJsonFixtureEqualsJsonObject('Unit/Resource/ContentType/Validation/enabled_marks_validation.json', $validation);
+    }
+
+    public function testGetSetData()
+    {
+        $validation = new EnabledMarksValidation(['bold', 'code']);
+
+        $this->assertSame(['RichText'], $validation->getValidFieldTypes());
+
+        $this->assertSame(['bold', 'code'], $validation->getEnabledMarks());
+
+        $validation->setEnabledMarks(['bold', 'italic']);
+        $this->assertSame(['bold', 'italic'], $validation->getEnabledMarks());
+    }
+}

--- a/tests/Unit/Resource/ContentType/Validation/EnabledNodeTypesValidationTest.php
+++ b/tests/Unit/Resource/ContentType/Validation/EnabledNodeTypesValidationTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * This file is part of the contentful/contentful-management package.
+ *
+ * @copyright 2015-2020 Contentful GmbH
+ * @license   MIT
+ */
+
+declare(strict_types=1);
+
+namespace Contentful\Tests\Management\Unit\Resource\ContentType\Validation;
+
+use Contentful\Management\Resource\ContentType\Validation\EnabledNodeTypesValidation;
+use Contentful\Tests\Management\BaseTestCase;
+
+class EnabledNodeTypesValidationTest extends BaseTestCase
+{
+    public function testJsonSerialize()
+    {
+        $validation = new EnabledNodeTypesValidation(['heading-1', 'heading-2', 'ordered-list']);
+
+        $this->assertJsonFixtureEqualsJsonObject(
+            'Unit/Resource/ContentType/Validation/enabled_node_types_validation.json',
+            $validation
+        );
+    }
+
+    public function testGetSetData()
+    {
+        $validation = new EnabledNodeTypesValidation(['heading-1', 'heading-2', 'ordered-list']);
+
+        $this->assertSame(['RichText'], $validation->getValidFieldTypes());
+
+        $this->assertSame(['heading-1', 'heading-2', 'ordered-list'], $validation->getEnabledNodeTypes());
+
+        $validation->setEnabledNodeTypes(
+            [
+                'hyperlink',
+                'entry-hyperlink',
+                'asset-hyperlink',
+                'embedded-asset-block',
+                'embedded-entry-inline',
+                'embedded-entry-block',
+            ]
+        );
+
+        $this->assertSame(
+            [
+                'hyperlink',
+                'entry-hyperlink',
+                'asset-hyperlink',
+                'embedded-asset-block',
+                'embedded-entry-inline',
+                'embedded-entry-block',
+            ],
+            $validation->getEnabledNodeTypes()
+        );
+    }
+}

--- a/tests/Unit/Resource/ContentType/Validation/NodesValidationTest.php
+++ b/tests/Unit/Resource/ContentType/Validation/NodesValidationTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * This file is part of the contentful/contentful-management package.
+ *
+ * @copyright 2015-2020 Contentful GmbH
+ * @license   MIT
+ */
+
+declare(strict_types=1);
+
+namespace Contentful\Tests\Management\Unit\Resource\ContentType\Validation;
+
+use Contentful\Management\Resource\ContentType\Validation\LinkContentTypeValidation;
+use Contentful\Management\Resource\ContentType\Validation\NodesValidation;
+use Contentful\Management\Resource\ContentType\Validation\SizeValidation;
+use Contentful\Tests\Management\BaseTestCase;
+
+class NodesValidationTest extends BaseTestCase
+{
+    public function testJsonSerialize()
+    {
+        $validation = new NodesValidation(
+            [new SizeValidation(1)],
+            [new SizeValidation(null, 1)],
+            [new LinkContentTypeValidation(['test']), new SizeValidation(1, 2)],
+            [new LinkContentTypeValidation(['test']), new SizeValidation(1)],
+            [new LinkContentTypeValidation(['test']), new SizeValidation(1)]
+        );
+
+        $this->assertJsonFixtureEqualsJsonObject(
+            'Unit/Resource/ContentType/Validation/nodes_validation.json',
+            $validation
+        );
+    }
+
+    public function testGetSetData()
+    {
+        $sizeValidation = new SizeValidation(1);
+        $linkContentTypeValidation = new LinkContentTypeValidation(['test']);
+
+        $validation = new NodesValidation(
+            [$sizeValidation],
+            [$sizeValidation],
+            [$linkContentTypeValidation, $sizeValidation],
+            [$linkContentTypeValidation, $sizeValidation],
+            [$linkContentTypeValidation, $sizeValidation]
+        );
+
+        $this->assertSame(['RichText'], $validation->getValidFieldTypes());
+
+        $this->assertSame([$sizeValidation], $validation->getAssetHyperlinkValidations());
+        $this->assertSame([$sizeValidation], $validation->getEmbeddedAssetBlockValidations());
+        $this->assertSame([$linkContentTypeValidation, $sizeValidation], $validation->getEmbeddedEntryBlockValidations());
+        $this->assertSame([$linkContentTypeValidation, $sizeValidation], $validation->getEmbeddedEntryInlineValidations());
+        $this->assertSame([$linkContentTypeValidation, $sizeValidation], $validation->getEntryHyperlinkValidations());
+    }
+
+    public function testGetAddedData()
+    {
+        $sizeValidation = new SizeValidation(1);
+
+        $validation = new NodesValidation([], [], [], [], []);
+
+        $this->assertSame([], $validation->getAssetHyperlinkValidations());
+        $this->assertSame([], $validation->getEmbeddedAssetBlockValidations());
+        $this->assertSame([], $validation->getEmbeddedEntryBlockValidations());
+        $this->assertSame([], $validation->getEmbeddedEntryInlineValidations());
+        $this->assertSame([], $validation->getEntryHyperlinkValidations());
+
+        $validation->addAssetHyperlinkValidation($sizeValidation);
+        $validation->addEmbeddedAssetBlockValidation($sizeValidation);
+        $validation->addEmbeddedEntryBlockValidation($sizeValidation);
+        $validation->addEmbeddedEntryInlineValidation($sizeValidation);
+        $validation->addEntryHyperlinkValidation($sizeValidation);
+
+        $this->assertSame([$sizeValidation], $validation->getAssetHyperlinkValidations());
+        $this->assertSame([$sizeValidation], $validation->getEmbeddedAssetBlockValidations());
+        $this->assertSame([$sizeValidation], $validation->getEmbeddedEntryBlockValidations());
+        $this->assertSame([$sizeValidation], $validation->getEmbeddedEntryInlineValidations());
+        $this->assertSame([$sizeValidation], $validation->getEntryHyperlinkValidations());
+    }
+}


### PR DESCRIPTION
I took my first foray into using this SDK yesterday but quickly ran into issues. Namely:

1. Cannot update any content type which contains a rich text field.

The `NodesValidation::jsonSerialize` method is hardcoded to return `[]`, however an object is expected as evidenced by the response:

```
"details": {
      "errors": [
        {
          "name": "type",
          "details": "The type of \"validations[1]\" is incorrect, expected type: Object",
          "path": [
            "fields",
            1,
            "validations",
            1
          ],
          "type": "Object",
          "value": []
        }
```

I can see that the [justification for this change](https://github.com/contentful/contentful-management.php/pull/149#issuecomment-584667673) was that the empty `nodes` object is always present when retrieving rich text content types. My proposed solution here is instead just to ignore the empty `nodes` object from `validations` when mapping the response.


2. Rich text validations (`nodes`, `enabledMarks` and `enabledNodeTypes`) all suffer from the above problem - and presumably even if the intention of the existing code worked correctly, we would be overwriting any defined validations by hardcoding this to be empty?

I've made a first pass at implementing the correct validations for a rich text field.

3. Custom validation messages on fields are overwritten (emptied) when updating a content type

4. Fields which have a custom validation message - where the validation key comes after `message` alphanumerically e.g. `size` -  will throw an exception (`MessageValidation` class not found)
 
The `BaseField::mapValidation()` method assumes the first key will correspond to `size`, `range`, etc (see `array_keys($data)[0]`) however this is not true where a `message` is included.

Ostensibly these last two bugs have always existed but have somehow gone unnoticed; I can only assume adding custom validation messages isn't a commonly-used feature 😄 

---

I'm not yet completely au fait with the code here and I'm not precious about the implementation details of these fixes so I am of course happy for any of this to be adapted by others if necessary - or to make further changes upon feedback :)