### PR TITLE
Fix initUpdatedBy to check for updatedBy key

### DIFF
--- a/src/SystemProperties/Component/UpdatedByTrait.php
+++ b/src/SystemProperties/Component/UpdatedByTrait.php
@@ -22,7 +22,7 @@ trait UpdatedByTrait
 
     protected function initUpdatedBy(array $data)
     {
-        if (isset($data['createdBy'])) {
+        if (isset($data['updatedBy'])) {
             $this->updatedBy = new Link($data['updatedBy']['sys']['id'], $data['updatedBy']['sys']['linkType']);
         }
     }


### PR DESCRIPTION
I’m having an issue with the Management API because the `updatedBy` field is missing in the data array. From what I can see in the code, the check is currently based on whether `createdBy` is set, while the value being used is `updatedBy`. Was this intentional?

I tested my changes locally, and everything appears to be working correctly now after changing the check to use `updatedBy` instead.

Here is the exception that was thrown:

```
10:22:22 CRITICAL  [console] Error thrown while running command "REDACTED". Message: "Contentful\Core\Api\Link::__construct(): Argument #1 ($linkId) must be of type string, null given, called in /var/www/html/vendor/contentful/contentful-management/src/SystemProperties/Component/UpdatedByTrait.php on line 26" ["exception" => TypeError { …},"command" => "REDACTED","message" => "Contentful\Core\Api\Link::__construct(): Argument #1 ($linkId) must be of type string, null given, called in /var/www/html/vendor/contentful/contentful-management/src/SystemProperties/Component/UpdatedByTrait.php on line 26"]
 
In Link.php line 34:
  Contentful\Core\Api\Link::__construct(): Argument #1 ($linkId) must be of type string, null given, called in /var/www/html/vendor/contentful/contentful-management/src/SystemProperties/Component/UpdatedByTrait.php on line 26
``` 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<p>The PR addresses an issue where the 'updatedBy' field is missing in the data array, causing a TypeError in the Link constructor. The fix changes the condition in initUpdatedBy to check for 'updatedBy' instead of 'createdBy', as tested locally.</p>


<details>
<summary><i>Detailed Changes</i></summary>
<ul>

<li>Changes the isset check in initUpdatedBy from 'createdBy' to 'updatedBy' in UpdatedByTrait.php to match the data being used.</li>

</ul>
</details>

</div>